### PR TITLE
Exclude queen from Rook Contact Check computation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -438,7 +438,7 @@ namespace {
         {
             // ...and then remove squares not supported by another enemy piece
             b &= (  ei.attackedBy[Them][PAWN]   | ei.attackedBy[Them][KNIGHT]
-                  | ei.attackedBy[Them][BISHOP] | ei.attackedBy[Them][QUEEN]);
+                  | ei.attackedBy[Them][BISHOP]);
 
             if (b)
                 attackUnits += RookContactCheck * popcount<Max15>(b);


### PR DESCRIPTION
In ei.attackedBy, Queen does not x-ray through Rook, but the Rook does
X-ray through the Queen.

So most of the rook contact checks supported by queen are, in fact,
Queen Contact Checks and they are already scored separately.

Bench: 7762189

Resolves #338