### PR TITLE
Also calculate st->checkersBB ifndef HORDE.

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -441,7 +441,9 @@ void Position::set_state(StateInfo* si) const {
   }
   else
   {
+#endif
       si->checkersBB = attackers_to(king_square(sideToMove)) & pieces(~sideToMove);
+#ifdef HORDE
   }
 #endif
 


### PR DESCRIPTION
At the moment, if `HORDE` is not defined, `si->checkersBB` will not be calculated in the standard way.