### PR TITLE
Significant evaluation improvements for 3Check, KotH and Horde

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -815,9 +815,9 @@ namespace {
 #ifdef HORDE
     if (pos.is_horde() && Us == WHITE)
     {
-        weight += weight + pos.count<PAWN>(Them);
-        bonus = bonus * weight * weight / 15;
-        return make_score(bonus, bonus) + make_score(pos.non_pawn_material(BLACK)/3,0);
+        weight = (pos.count<PAWN>(Us) + int(pos.non_pawn_material(BLACK)/PawnValueMg))/5;
+        bonus = bonus * weight * weight / 10;
+        return make_score(bonus, bonus) + make_score(pos.non_pawn_material(BLACK)/4,0);
     }
 #endif
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -816,8 +816,8 @@ namespace {
     if (pos.is_horde() && Us == WHITE)
     {
         weight += weight + pos.count<PAWN>(Them);
-        bonus = bonus * weight * weight / 4;
-        return make_score(bonus, bonus);
+        bonus = bonus * weight * weight / 15;
+        return make_score(bonus, bonus) + make_score(pos.non_pawn_material(BLACK)/3,0);
     }
 #endif
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -617,9 +617,14 @@ namespace {
 #ifdef KOTH
     if (pos.is_koth())
     {
-        int r = RANK_7 - pos.koth_distance(Us);
-        Value mbonus = Passed[MG][r], ebonus = Passed[EG][r];
-        score += make_score(mbonus, ebonus);
+        Square ksq = pos.square<KING>(Us);
+        Square center[4] = {SQ_E4, SQ_D4, SQ_D5, SQ_E5};
+        for(int i = 0; i<4; i++){        
+            int dist = distance(ksq, center[i])+popcount(pos.attackers_to(center[i]) & pos.pieces(Them))+popcount(pos.pieces(Us) & center[i]) ;
+            int r = std::max(RANK_7 - dist, 0);
+            Value mbonus = Passed[MG][r], ebonus = 2*Passed[EG][r];
+            score += make_score(mbonus, ebonus);
+        }
     }
 #endif
     while (b)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -925,8 +925,13 @@ Value Eval::evaluate(const Position& pos) {
         if (pos.is_three_check_loss())
             return -VALUE_MATE;
 
-        score += ChecksGivenBonus[pos.checks_given()];
-        score -= ChecksGivenBonus[pos.checks_taken()];
+        if(pos.side_to_move() == WHITE){
+            score += ChecksGivenBonus[pos.checks_given()];
+            score -= ChecksGivenBonus[pos.checks_taken()];
+        }else{
+            score -= ChecksGivenBonus[pos.checks_given()];
+            score += ChecksGivenBonus[pos.checks_taken()];
+        }
     }
 #endif
 #ifdef HORDE


### PR DESCRIPTION
Hi, I have made some changes to the evaluation of the mentioned variants:

- fixed a bug in the evaluation of three-check chess: ChecksGivenBonus had the wrong sign if was black's move. A test on very short time controls resulted in [344, 55, 1] with +317 Elo.
- distance to center in KotH is now the minimum number of moves needed to move the king to a square in the center. This means that the number of opponent's pieces controlling the square is added to the distance (you have to deflect or take each piece) and 1 is added if an own piece blocks the square. Local testing result: [145, 48, 7], +184 Elo. Possible improvement: blocked squares on the king's way to the center are not taken into account yet.
- white's space bonus in horde chess was decreasing very fast in the opening, so I tried to stabilize and improve the evaluation there. The results are: [334, 62, 4], +288 Elo. However, there probably is a lot of room for improvements, because I have only tested a few sets of parameter values.

The Elo gains seem to be huge, but more testing especially on longer time controls would be necessary to confirm the results. Tests with fewer games but longer time control indicate that scaling with time is not bad.