### PR TITLE
new SEE for atomic variant + evaluation function tweaks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -844,9 +844,9 @@ namespace {
 #ifdef HORDE
     if (pos.is_horde() && Us == WHITE)
     {
-        weight = (pos.count<PAWN>(Us) + int(pos.non_pawn_material(BLACK)/PawnValueMg))/5;
-        bonus = bonus * weight * weight / 10;
-        return make_score(bonus, bonus) + make_score(pos.non_pawn_material(BLACK)/4,0);
+        weight = pos.count<PAWN>(Us) + int(pos.non_pawn_material(BLACK)/PawnValueMg);
+        bonus = bonus * weight * weight / 200;
+        return make_score(bonus, bonus) + make_score(pos.non_pawn_material(BLACK) * 2 / 9,0);
     }
 #endif
 #ifdef KOTH

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -849,6 +849,12 @@ namespace {
         return make_score(bonus, bonus) + make_score(pos.non_pawn_material(BLACK)/4,0);
     }
 #endif
+#ifdef KOTH
+    if (pos.is_koth()){
+        int koth_bonus = 200*popcount(safe & behind & (Rank4BB | Rank5BB) & (FileDBB | FileEBB));
+        return make_score(bonus * weight * weight * 2 / 11, 0) + make_score(koth_bonus, koth_bonus);
+    }
+#endif
 
     return make_score(bonus * weight * weight * 2 / 11, 0);
   }

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1088,6 +1088,10 @@ Value Eval::evaluate(const Position& pos) {
 #ifdef HORDE
   }
 #endif
+#ifdef ATOMIC
+  if (pos.is_atomic())
+      score -= make_score(pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK),pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK))/4;
+#endif
 
   // Evaluate scale factor for the winning side
   ScaleFactor sf = evaluate_scale_factor(pos, ei, eg_value(score));

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -651,7 +651,7 @@ namespace {
         for(int i = 0; i<4; i++){        
             int dist = distance(ksq, center[i])+popcount(pos.attackers_to(center[i]) & pos.pieces(Them))+popcount(pos.pieces(Us) & center[i]) ;
             int r = std::max(RANK_7 - dist, 0);
-            Value mbonus = Passed[MG][r], ebonus = 2*Passed[EG][r];
+            Value mbonus = 2*Passed[MG][r], ebonus = 4*Passed[EG][r];
             score += make_score(mbonus, ebonus);
         }
     }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1399,6 +1399,22 @@ Value Position::see(Move m) const {
   swapList[0] = PieceValue[MG][piece_on(to)];
   stm = color_of(piece_on(from));
   occupied = pieces() ^ from;
+#ifdef ATOMIC
+  if(is_atomic())
+  {
+    Value blast_eval = VALUE_ZERO;
+    Bitboard blast = attacks_from<KING>(to) & (pieces() ^ pieces(PAWN)) & ~SquareBB[from];
+    if(blast & pieces(~stm,KING))
+        return VALUE_MATE;
+    for (Color c = WHITE; c <= BLACK; ++c)
+        for (PieceType pt = KNIGHT; pt <= QUEEN; ++pt)
+            if(c == stm)
+                blast_eval -= popcount(blast & pieces(c,pt))*PieceValue[MG][pt];
+            else
+                blast_eval += popcount(blast & pieces(c,pt))*PieceValue[MG][pt];
+    return blast_eval + PieceValue[MG][piece_on(to_sq(m))] - PieceValue[MG][moved_piece(m)];
+  }
+#endif
 
   // Castling moves are implemented as king capturing the rook so cannot
   // be handled correctly. Simply return VALUE_ZERO that is always correct

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -42,6 +42,10 @@ namespace {
   // FEN string of the initial position, horde variant
   const char* StartFENHorde = "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1";
 #endif
+#ifdef RACE
+  // FEN string of the initial position, race variant
+  const char* StartFENRace = "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1";
+#endif
 
   // A list to keep track of the position states along the setup moves (from the
   // start position to the position just before the search starts). Needed by
@@ -91,8 +95,14 @@ namespace {
     if (token == "startpos")
     {
 #ifdef HORDE
-        fen = (variant & HORDE_VARIANT) ? StartFENHorde : StartFEN;
-#else
+        if(variant & HORDE_VARIANT)
+            fen = StartFENHorde;
+        else
+#ifdef RACE
+        if(variant & RACE_VARIANT)
+            fen = StartFENRace;
+        else
+#endif
         fen = StartFEN;
 #endif
         is >> token; // Consume "moves" token if any


### PR DESCRIPTION
- new SEE for atomic variant: The SEE from standard chess does not make much sense for atomic chess, so instead the material gain or loss from capture and explosion is now returned by the SEE. It stops after the first capture and hence does not account for X-ray attacks.
- tweaks in the evaluation function for horde, KotH, and atomic variant

Performance against current master:
Atomic: Total: 1000 W: 874 L: 57 D: 69 ELO: 398.76 +-33.5 (95%) LOS: 100.0%
KotH: Total: 1000 W: 567 L: 373 D: 60 ELO: 68.27 +-21.3 (95%) LOS: 100.0% 
Horde: Total: 1000 W: 603 L: 383 D: 14 ELO: 77.71 +-21.9 (95%) LOS: 100.0%

Is there an easy way to globally change the piece values only for specific variants? With my latest commit I try to take account of the fact that pawns are more valuable in atomic chess, but my code is most probably not the best way to do so.