### PR TITLE
Rewrite Racing Kings advanced king evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -658,7 +658,8 @@ namespace {
     {
         Square ksq = pos.square<KING>(Us);
         Square center[4] = {SQ_E4, SQ_D4, SQ_D5, SQ_E5};
-        for(int i = 0; i<4; i++){        
+        for (int i = 0; i<4; i++)
+        {
             int dist = distance(ksq, center[i])+popcount(pos.attackers_to(center[i]) & pos.pieces(Them))+popcount(pos.pieces(Us) & center[i]) ;
             int r = std::max(RANK_7 - dist, 0);
             Value mbonus = 2*Passed[MG][r], ebonus = 4*Passed[EG][r];
@@ -823,7 +824,8 @@ namespace {
     }
 #endif
 #ifdef KOTH
-    if (pos.is_koth()){
+    if (pos.is_koth())
+    {
         int koth_bonus = 200*popcount(safe & behind & (Rank4BB | Rank5BB) & (FileDBB | FileEBB));
         return make_score(bonus * weight * weight * 2 / 11, 0) + make_score(koth_bonus, koth_bonus);
     }
@@ -938,10 +940,13 @@ Value Eval::evaluate(const Position& pos) {
         if (pos.is_three_check_loss())
             return -VALUE_MATE;
 
-        if(pos.side_to_move() == WHITE){
+        if (pos.side_to_move() == WHITE)
+        {
             score += ChecksGivenBonus[pos.checks_given()];
             score -= ChecksGivenBonus[pos.checks_taken()];
-        }else{
+        }
+        else
+        {
             score -= ChecksGivenBonus[pos.checks_given()];
             score += ChecksGivenBonus[pos.checks_taken()];
         }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1400,15 +1400,15 @@ Value Position::see(Move m) const {
   stm = color_of(piece_on(from));
   occupied = pieces() ^ from;
 #ifdef ATOMIC
-  if(is_atomic())
+  if (is_atomic())
   {
     Value blast_eval = VALUE_ZERO;
     Bitboard blast = attacks_from<KING>(to) & (pieces() ^ pieces(PAWN)) & ~SquareBB[from];
-    if(blast & pieces(~stm,KING))
+    if (blast & pieces(~stm,KING))
         return VALUE_MATE;
     for (Color c = WHITE; c <= BLACK; ++c)
         for (PieceType pt = KNIGHT; pt <= QUEEN; ++pt)
-            if(c == stm)
+            if (c == stm)
                 blast_eval -= popcount(blast & pieces(c,pt))*PieceValue[MG][pt];
             else
                 blast_eval += popcount(blast & pieces(c,pt))*PieceValue[MG][pt];


### PR DESCRIPTION
I had already commited this a couple of days ago, but hesitated to create a pull request. The reason for my hesitation was that the changes do have significant impact on the shape of the search tree. To reach the same depth it now takes much more time and the respective selective search depth is higher. I think that this is caused by the huge bonus for the advanced king which leads to less stable evaluation and hence probably less pruning.

However, since the performance is incredible, I finally decided to create this pull request. Against the current master it scores very close to 100%. To verify that it does not only perform that well on very short time controls, a few games with time controls up to 1'+1'' have been played with a 100% score.

I (~2150 Elo) also played a few games against both versions at 1'+1'' to estimate the engines' playing strength. In games against the current master I could see that it significantly underestimates the value of the advanced king. One example of a surprisingly easy win: 1.Kg3 Be4 2.Kf4 Nxf2 3.Ke5 Nxh1 4.Kf6 Kb3 5.Ke7 Qa8 6.Rg8 Nxf1 7.Rd8 Qa2 8.Ke8 1-0. Against the new version my only chance to score was to take white and play opening lines I had analyzed before. This way I could get a draw a few times. I also had a few close to winning positions, but I was not able to win due to the engine's superior endgame play.

Feedback is very welcome.