### PR TITLE
Search and evaluation improvements

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -448,7 +448,7 @@ namespace {
         other = ~(   ei.attackedBy[Us][PAWN]
                   | (pos.pieces(Them, PAWN) & shift_bb<Up>(pos.pieces(PAWN))));
 #ifdef THREECHECK
-        if (pos.is_three_check() && pos.checks_taken())
+        if (pos.is_three_check() && (pos.side_to_move() == Us ? pos.checks_taken() : pos.checks_given()))
             other = safe = ~pos.pieces(Them);
 #endif
 
@@ -492,7 +492,7 @@ namespace {
 #ifdef THREECHECK
         if (pos.is_three_check())
         {
-            switch(pos.checks_taken())
+            switch(pos.side_to_move() == Us ? pos.checks_taken() : pos.checks_given())
             {
             case CHECKS_NB:
             case CHECKS_3:

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -666,9 +666,9 @@ namespace {
         for (int i = 0; i<4; i++)
         {
             int dist = distance(ksq, center[i])+popcount(pos.attackers_to(center[i]) & pos.pieces(Them))+popcount(pos.pieces(Us) & center[i]) ;
-            int r = std::max(RANK_7 - dist, 0);
-            Value mbonus = 2*Passed[MG][r], ebonus = 4*Passed[EG][r];
-            score += make_score(mbonus, ebonus);
+            assert(dist > 0);
+            Value bonus = RookValueMg / (dist * dist);
+            score += make_score(bonus, bonus);
         }
     }
 #endif

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -646,12 +646,11 @@ namespace {
     if (pos.is_race())
     {
         Square ksq = pos.square<KING>(Us);
-        int r = relative_rank(Up, ksq);
-        Value v = r * (r + 1) * PawnValueMg * 3 / 4;
-        Bitboard advances = in_front_bb(Us, rank_of(ksq)) & pos.attacks_from<KING>(ksq);
-        v -= (advances & ei.attackedBy[Them][ALL_PIECES]) == advances ? r * PawnValueMg : 0;
-        Bitboard blocked_squares = in_front_bb(Us, rank_of(ksq)) & ei.attackedBy[Them][ALL_PIECES];
-        v -= popcount(blocked_squares) * PawnValueMg / 5;
+        int s = relative_rank(BLACK, ksq);
+        for (Rank i = Rank(rank_of(ksq) + 1); i < RANK_8; ++i)
+            if (!(rank_bb(i) & DistanceRingBB[ksq][i - 1 - rank_of(ksq)] & ~ei.attackedBy[Them][ALL_PIECES] & ~pos.pieces(Us)))
+                s++;
+        Value v = MidgameLimit / (s + 1);
         score = make_score(v, v);
     }
     else

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -134,6 +134,11 @@ void MovePicker::score<CAPTURES>() {
   // badCaptures[] array, but instead of doing it now we delay until the move
   // has been picked up, saving some SEE calls in case we get a cutoff.
   for (auto& m : *this)
+#ifdef RACE
+      if (pos.is_race())
+          m.value = PieceValue[MG][pos.piece_on(to_sq(m))] - Value(200 * relative_rank(BLACK, to_sq(m)));
+      else
+#endif
       m.value =  PieceValue[MG][pos.piece_on(to_sq(m))]
                - Value(200 * relative_rank(pos.side_to_move(), to_sq(m)));
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1370,6 +1370,10 @@ Value Position::see_sign(Move m) const {
 
   assert(is_ok(m));
 
+#ifdef THREECHECK
+  if (is_three_check() && gives_check(m, CheckInfo(*this)))
+      return VALUE_KNOWN_WIN;
+#endif
   // Early return if SEE cannot be negative because captured piece value
   // is not less then capturing one. Note that king moves always return
   // here because king midgame value is set to 0.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -787,6 +787,10 @@ namespace {
 
     // Step 6. Razoring (skipped when in check)
     variantScale = 1;
+#ifdef ATOMIC
+    if (pos.is_atomic())
+        variantScale += 3;
+#endif
 #ifdef RACE
     if (pos.is_race())
         variantScale += raceRank / 2;


### PR DESCRIPTION
- more stable and simple racing kings advanced king evaluation (not tuned yet)
- less razoring and futility pruning in atomic variant
- all captures that give check get a positive SEE sign in three-check
- in three-check king safety evaluation function the same number of checks given/taken had been used for black and white
- captures closer to the 8th rank are preferred during move ordering in racing kings
- koth bonus changed to simple formula instead of using passed pawn bonus