### PR TITLE
Add Antichess variant support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -232,7 +232,7 @@ ifneq ($(comp),mingw)
 endif
 
 ### 3.2 Debugging
-CXXFLAGS += -DATOMIC -DHORDE -DHOUSE -DKOTH -DRACE -DTHREECHECK
+CXXFLAGS += -DATOMIC -DHORDE -DHOUSE -DKOTH -DRACE -DTHREECHECK -DANTI
 ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
 else

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -175,6 +175,10 @@ void benchmark(const Position& current, istream& is) {
       if (Options["UCI_3Check"])
           variant |= THREECHECK_VARIANT;
 #endif
+#ifdef ANTI
+      if (Options["UCI_Anti"])
+          variant |= ANTI_VARIANT;
+#endif
       StateListPtr states(new std::deque<StateInfo>(1));
       pos.set(fens[i], variant, &states->back(), Threads.main());
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -974,6 +974,16 @@ Value Eval::evaluate(const Position& pos) {
             return -VALUE_MATE;
     }
 #endif
+#ifdef ANTI
+    // Possibly redundant static evaluator
+    if (pos.is_anti())
+    {
+        if (pos.is_anti_win())
+            return VALUE_MATE;
+        if (pos.is_anti_loss())
+            return -VALUE_MATE;
+    }
+#endif
 
   // Probe the material hash table
   ei.me = Material::probe(pos);
@@ -995,6 +1005,9 @@ Value Eval::evaluate(const Position& pos) {
 #endif
 #ifdef ATOMIC
   if (pos.is_atomic()) {} else
+#endif
+#ifdef ANTI
+  if (pos.is_anti()) {} else
 #endif
   if (ei.me->specialized_eval_exists())
       return ei.me->evaluate(pos);
@@ -1027,6 +1040,9 @@ Value Eval::evaluate(const Position& pos) {
   score += evaluate_pieces<DoTrace>(pos, ei, mobility, mobilityArea);
   score += mobility[WHITE] - mobility[BLACK];
 
+#ifdef ANTI
+  if (pos.is_anti()) {} else
+#endif
   // Evaluate kings after all other pieces because we need full attack
   // information when computing the king safety evaluation.
   score +=  evaluate_king<WHITE, DoTrace>(pos, ei)

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -191,6 +191,9 @@ Entry* probe(const Position& pos) {
 #ifdef ATOMIC
           if (pos.is_atomic()) {} else
 #endif
+#ifdef ANTI
+          if (pos.is_anti()) {} else
+#endif
           assert(pos.count<PAWN>(WHITE) >= 2);
 
           e->scalingFunction[WHITE] = &ScaleKPsK[WHITE];
@@ -211,6 +214,9 @@ Entry* probe(const Position& pos) {
 #endif
 #ifdef ATOMIC
           if (pos.is_atomic()) {} else
+#endif
+#ifdef ANTI
+          if (pos.is_anti()) {} else
 #endif
           assert(pos.count<PAWN>(BLACK) >= 2);
 

--- a/src/material.h
+++ b/src/material.h
@@ -65,6 +65,9 @@ struct Entry {
 #ifdef ATOMIC
     if (pos.is_atomic()) return SCALE_FACTOR_NORMAL;
 #endif
+#ifdef ANTI
+    if (pos.is_anti()) return SCALE_FACTOR_NORMAL;
+#endif
     ScaleFactor sf = scalingFunction[c] ? (*scalingFunction[c])(pos)
                                         :  SCALE_FACTOR_NONE;
     return sf != SCALE_FACTOR_NONE ? sf : ScaleFactor(factor[c]);

--- a/src/position.h
+++ b/src/position.h
@@ -39,6 +39,7 @@
 #define KOTH_VARIANT 1 << 5
 #define RACE_VARIANT 1 << 6
 #define THREECHECK_VARIANT 1 << 7
+#define ANTI_VARIANT 1 << 8
 
 class Position;
 class Thread;
@@ -217,6 +218,11 @@ public:
   Checks checks_given() const;
   Checks checks_taken() const;
 #endif
+#ifdef ANTI
+  bool is_anti() const;
+  bool is_anti_win() const;
+  bool is_anti_loss() const;
+#endif
   Thread* this_thread() const;
   uint64_t nodes_searched() const;
   void set_nodes_searched(uint64_t n);
@@ -324,6 +330,10 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
 #endif
 #ifdef ATOMIC
   if (is_atomic() && pieceCount[c][Pt] == 0)
+      return SQ_NONE;
+#endif
+#ifdef ANTI
+  if (is_anti() && pieceCount[c][Pt] == 0)
       return SQ_NONE;
 #endif
   assert(pieceCount[c][Pt] == 1);
@@ -496,6 +506,20 @@ inline bool Position::is_horde() const {
 // Loss if horde is captured (Horde)
 inline bool Position::is_horde_loss() const {
   return count<ALL_PIECES>(WHITE) == 0;
+}
+#endif
+
+#ifdef ANTI
+inline bool Position::is_anti() const {
+  return var & ANTI_VARIANT;
+}
+
+inline bool Position::is_anti_loss() const {
+  return count<ALL_PIECES>(~sideToMove) == 0;
+}
+
+inline bool Position::is_anti_win() const {
+  return count<ALL_PIECES>(sideToMove) == 0;
 }
 #endif
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -282,6 +282,10 @@ void MainThread::search() {
       if (rootPos.is_atomic() && rootPos.is_atomic_loss())
           score = -VALUE_MATE;
 #endif
+#ifdef ANTI
+      if (rootPos.is_anti() && rootPos.is_anti_loss())
+          score = -VALUE_MATE;
+#endif
       sync_cout << "info depth 0 score " << UCI::value(score) << sync_endl;
   }
   else
@@ -652,6 +656,16 @@ namespace {
         if (pos.is_horde() && pos.is_horde_loss())
             return mated_in(ss->ply);
 #endif
+#ifdef ANTI
+        // Check for an instant loss (Anti)
+        if (pos.is_anti())
+        {
+            if (pos.is_anti_win())
+                return mate_in(ss->ply + 1);
+            if (pos.is_anti_loss())
+                return mated_in(ss->ply);
+        }
+#endif
 #ifdef ATOMIC
         // Check for an instant loss (Atomic)
         if (pos.is_atomic() && pos.is_atomic_loss())
@@ -724,6 +738,9 @@ namespace {
 #endif
 #ifdef ATOMIC
     if (pos.is_atomic()) {} else
+#endif
+#ifdef ANTI
+    if (pos.is_anti()) {} else
 #endif
     if (!rootNode && TB::Cardinality)
     {
@@ -1299,6 +1316,11 @@ moves_loop: // When in check search starts from here
             bestValue = excludedMove ? alpha : mated_in(ss->ply);
         else
 #endif
+#ifdef ANTI
+        if (pos.is_anti())
+            bestValue = mate_in(ss->ply+1);
+        else
+#endif
         bestValue = excludedMove ? alpha
                    :     inCheck ? mated_in(ss->ply) : DrawValue[pos.side_to_move()];
     }
@@ -1420,6 +1442,16 @@ moves_loop: // When in check search starts from here
         if (pos.is_atomic_win())
             return mate_in(ss->ply + 1);
         if (pos.is_atomic_loss())
+            return mated_in(ss->ply);
+    }
+#endif
+#ifdef ANTI
+    // Check for an instant win (Anti)
+    if (pos.is_anti())
+    {
+        if (pos.is_anti_win())
+            return mate_in(ss->ply + 1);
+        if (pos.is_anti_loss())
             return mated_in(ss->ply);
     }
 #endif

--- a/src/types.h
+++ b/src/types.h
@@ -418,6 +418,10 @@ inline MoveType type_of(Move m) {
 }
 
 inline PieceType promotion_type(Move m) {
+#ifdef ANTI
+  if ((m >> 16) & 1)
+      return KING;
+#endif
   return PieceType(((m >> 12) & 3) + KNIGHT);
 }
 
@@ -427,6 +431,10 @@ inline Move make_move(Square from, Square to) {
 
 template<MoveType T>
 inline Move make(Square from, Square to, PieceType pt = KNIGHT) {
+#ifdef ANTI
+  if (pt == KING)
+      return Move(to | (from << 6) | T | ((pt - KNIGHT) << 12) | (1 << 16));
+#endif
   return Move(to | (from << 6) | T | ((pt - KNIGHT) << 12));
 }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -90,6 +90,10 @@ namespace {
     if (Options["UCI_3Check"])
         variant |= THREECHECK_VARIANT;
 #endif
+#ifdef ANTI
+    if (Options["UCI_Anti"])
+        variant |= ANTI_VARIANT;
+#endif
 
     is >> token;
     if (token == "startpos")

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -88,6 +88,9 @@ void init(OptionsMap& o) {
 #ifdef THREECHECK
   o["UCI_3Check"]            << Option(false);
 #endif
+#ifdef ANTI
+  o["UCI_Anti"]              << Option(false);
+#endif
   o["SyzygyPath"]            << Option("<empty>", on_tb_path);
   o["SyzygyProbeDepth"]      << Option(1, 1, 100);
   o["Syzygy50MoveRule"]      << Option(true);


### PR DESCRIPTION
The lichess Antichess rules are implemented:
- capturing is mandatory
- king can be captured
- no castling
- promotion to king is allowed
- to get stalemated is a win

Since the promotion piece is encoded with two bits in Stockfish I had to add a bit to the move encoding for king promotions.

The evaluation function and the search haven't been adjusted yet, but it can still find forced wins more than 15 ply ahead within seconds. To find a good evaluation function is probably tricky. I will start by using negative piece values.

I could not validate the move generation so far, because I haven't found any antichess perft results to compare to. "perft 6" on the starting position gives:
a2a3: 2063218
b2b3: 2605735
c2c3: 2533781
d2d3: 3236018
e2e3: 3140980
f2f3: 2507652
g2g3: 2633779
h2h3: 2055782
a2a4: 2718800
b2b4: 1413213
c2c4: 2288857
d2d4: 2351161
e2e4: 2173611
f2f4: 2264190
g2g4: 1384943
h2h4: 2298542
b1a3: 1955909
b1c3: 2387358
g1f3: 2404586
g1h3: 1965542
Nodes searched  : 46383657