### PR TITLE
Fix Antichess en passant move generation bug

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -145,6 +145,10 @@ namespace {
     if (Type != CAPTURES)
     {
         emptySquares = (Type == QUIETS || Type == QUIET_CHECKS ? target : ~pos.pieces());
+#ifdef ANTI
+        if (pos.is_anti())
+            emptySquares &= target;
+#endif
 
         Bitboard b1 = shift_bb<Up>(pawnsNotOn7)   & emptySquares;
         Bitboard b2 = shift_bb<Up>(b1 & TRank3BB) & emptySquares;
@@ -203,6 +207,10 @@ namespace {
                 emptySquares &= target;
 #endif
         }
+#ifdef ANTI
+        if (pos.is_anti())
+            emptySquares &= target;
+#endif
 
         if (Type == EVASIONS)
             emptySquares &= target;
@@ -538,9 +546,6 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 #ifdef RACE
   if (pos.is_race()) validate = true;
 #endif
-#ifdef ANTI
-  if (pos.is_anti()) validate = false;
-#endif
   Square ksq = pos.square<KING>(pos.side_to_move());
   ExtMove* cur = moveList;
   moveList = pos.checkers() ? generate<EVASIONS    >(pos, moveList)
@@ -551,10 +556,6 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
           *cur = (--moveList)->move;
 #ifdef ATOMIC
       else if (pos.is_atomic() && pos.capture(*cur) && !pos.legal(*cur, pinned))
-          *cur = (--moveList)->move;
-#endif
-#ifdef ANTI
-      else if (pos.is_anti() && type_of(pos.piece_on(from_sq(*cur))) == PAWN && !pos.legal(*cur, pinned))
           *cur = (--moveList)->move;
 #endif
       else

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -284,6 +284,9 @@ Move MovePicker::next_move() {
 
       case KILLERS:
           move = *cur++;
+#ifdef ANTI
+          if (pos.is_anti() && pos.can_capture()) {} else
+#endif
           if (    move != MOVE_NONE
               &&  move != ttMove
               &&  pos.pseudo_legal(move)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -620,18 +620,7 @@ bool Position::legal(Move m, Bitboard pinned) const {
   // If a player can capture, that player must capture
   // Ideally move generator should handle this
   if (is_anti())
-  {
-      if (capture(m))
-          return true;
-      Bitboard b = pieces(us);
-      while (b)
-      {
-          Square s = pop_lsb(&b);
-          if (attacks_from(piece_on(s), s) & pieces(~us))
-              return false;
-      }
-      return true;
-  }
+      return capture(m) == can_capture();
 #endif
 #ifdef HORDE
   assert(is_horde() && us == WHITE ? square<KING>(us) == SQ_NONE : piece_on(square<KING>(us)) == make_piece(us, KING));

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -618,9 +618,10 @@ bool Position::legal(Move m, Bitboard pinned) const {
   assert(color_of(moved_piece(m)) == us);
 #ifdef ANTI
   // If a player can capture, that player must capture
-  // Ideally move generator should handle this
+  // Is handled by move generator
+  assert(!is_anti() || capture(m) == can_capture(m));
   if (is_anti())
-      return capture(m) == can_capture();
+      return true;
 #endif
 #ifdef HORDE
   assert(is_horde() && us == WHITE ? square<KING>(us) == SQ_NONE : piece_on(square<KING>(us)) == make_piece(us, KING));

--- a/src/position.h
+++ b/src/position.h
@@ -222,6 +222,7 @@ public:
   bool is_anti() const;
   bool is_anti_win() const;
   bool is_anti_loss() const;
+  bool can_capture() const;
 #endif
   Thread* this_thread() const;
   uint64_t nodes_searched() const;
@@ -521,6 +522,20 @@ inline bool Position::is_anti_loss() const {
 
 inline bool Position::is_anti_win() const {
   return count<ALL_PIECES>(sideToMove) == 0;
+}
+
+inline bool Position::can_capture() const {
+  if (ep_square() != SQ_NONE)
+      if (attackers_to(ep_square()) & pieces(sideToMove, PAWN))
+          return true;
+  Bitboard b = pieces(sideToMove);
+  while (b)
+  {
+      Square s = pop_lsb(&b);
+      if (attacks_from(piece_on(s), s) & pieces(~sideToMove))
+          return true;
+  }
+  return false;
 }
 #endif
 


### PR DESCRIPTION
In the case of en passant captures the destination square of a capture is empty. This had not been taken account of in Antichess, so I fixed it. 

Furthermore, the move validation is now handled during move generation. Killer moves are omitted during move picking if there is a capture to avoid having to check move legality afterwards.

The perft results are now in agreement with https://sites.google.com/site/dshawul/home.
a2a3: 2060617
b2b3: 2602974
c2c3: 2531638
d2d3: 3233771
e2e3: 3139671
f2f3: 2504977
g2g3: 2631070
h2h3: 2053087
a2a4: 2710239
b2b4: 1399843
c2c4: 2276329
d2d4: 2338832
e2e4: 2161741
f2f4: 2251339
g2g4: 1373678
h2h4: 2289701
b1a3: 1953706
b1c3: 2385274
g1f3: 2402530
g1h3: 1963145
Nodes searched  : 46264162