### PR TITLE
Skip null move search if we have to capture in Antichess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -845,6 +845,9 @@ namespace {
         return eval - (futility_margin(depth) * variantScale);
 
     // Step 8. Null move search with verification search (is omitted in PV nodes)
+#ifdef ANTI
+    if (pos.is_anti() && pos.can_capture()) {} else
+#endif
     if (   !PvNode
         &&  eval >= beta
         && (ss->staticEval >= beta - 35 * (depth / ONE_PLY - 6) || depth >= 13 * ONE_PLY)


### PR DESCRIPTION
Null move search does not really make sense if there is a forced capture, so just skip it then. The test results are surprisingly good:
ELO: 197.87 +-21.3 (95%) LOS: 100.0%
Total: 1000 W: 654 L: 139 D: 207

It can now find a forced win for black after 1.d3, 1.d4, 1.e4 and 1.h4 within a few seconds.