### PR TITLE
Evaluation improvements

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -676,6 +676,29 @@ namespace {
     // Count all these squares with a single popcount
     score += make_score(7 * popcount(b), 0);
 
+#ifdef HORDE
+    if (pos.is_horde() && Us == BLACK)
+    {
+        // Add a bonus according to how close black is to breaking through the pawn wall
+        if (pos.pieces(BLACK, ROOK) | pos.pieces(BLACK, QUEEN))
+        {
+            int min = 8;
+            if ((ei.attackedBy[Us][QUEEN] | ei.attackedBy[Us][ROOK]) & rank_bb(RANK_1))
+                min = 0;
+            else
+            {
+                for (File f = FILE_A; f <= FILE_H; ++f)
+                {
+                    int pawns = popcount(pos.pieces(WHITE, PAWN) & file_bb(f));
+                    int pawnsl = f > FILE_A ? std::min(popcount(pos.pieces(WHITE, PAWN) & FileBB[f - 1]), pawns) : 0;
+                    int pawnsr = f < FILE_H ? std::min(popcount(pos.pieces(WHITE, PAWN) & FileBB[f + 1]), pawns) : 0;
+                    min = std::min(min, pawnsl + pawnsr);
+                }
+            }
+            score += ThreatByHangingPawn * pos.count<PAWN>(WHITE) / (1 + min) / (pos.pieces(BLACK, QUEEN) ? 2 : 4);
+        }
+    }
+#endif
 #ifdef ANTI
     }
 #endif

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -512,9 +512,9 @@ namespace {
             {
             case CHECKS_NB:
             case CHECKS_3:
-            case CHECKS_2:  attackUnits += RookCheck; break;
-            case CHECKS_1:  attackUnits += KnightCheck + attackUnits / 2; break;
-            case CHECKS_0:  attackUnits += BishopCheck + attackUnits; break;
+            case CHECKS_2:  attackUnits += 2 * attackUnits; break;
+            case CHECKS_1:  attackUnits += attackUnits; break;
+            case CHECKS_0:  attackUnits += attackUnits / 2; break;
             }
         }
 #endif


### PR DESCRIPTION
- Some intuitive changes to king safety and threats evaluation in atomic chess, e.g. because king cannot capture and pieces do not have to be protected. Additionaly, introduce a penalty for pieces directly adjacent to king.
- Tweak values that are added to attackUnits (->king danger) according to the number of checks taken in three-check.
- Add a new bonus in horde chess to give the engine an idea of how to win with black in horde chess. I think this idea has some more potential.