### PR TITLE
Do not extend king advances in Racing Kings

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1011,12 +1011,6 @@ moves_loop: // When in check search starts from here
       captureOrPromotion = pos.capture_or_promotion(move);
       moved_piece = pos.moved_piece(move);
 
-#ifdef RACE
-      if (pos.is_race())
-          givesCheck = type_of(pos.piece_on(from_sq(move))) == KING &&
-              rank_of(to_sq(move)) > rank_of(from_sq(move));
-      else
-#endif
       givesCheck =  type_of(move) == NORMAL && !ci.dcCandidates
 #ifdef ATOMIC
                   && !pos.is_atomic()
@@ -1070,6 +1064,9 @@ moves_loop: // When in check search starts from here
       newDepth = depth - ONE_PLY + extension;
 
       // Step 13. Pruning at shallow depth
+#ifdef RACE
+      if (pos.is_race() && type_of(moved_piece) == KING && rank_of(to_sq(move)) > rank_of(from_sq(move))) {} else
+#endif
       if (   !rootNode
           && !captureOrPromotion
           && !inCheck


### PR DESCRIPTION
Extending king advances (by one ply) in Racing Kings leads to very high selective depths (e.g. depth 9, sel. depth 27). Removing it proves to be an improvement and should also make the search more stable.