### PR TITLE
Bugfix for final positions in Racing Kings

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -581,18 +581,20 @@ inline bool Position::is_race() const {
 
 // Win if king is on the eighth rank (Racing Kings)
 inline bool Position::is_race_win() const {
-  return rank_of(square<KING>(sideToMove)) == RANK_8;
+  return rank_of(square<KING>(sideToMove)) == RANK_8
+        && rank_of(square<KING>(~sideToMove)) < RANK_8;
 }
 
 // Draw if kings are on the eighth rank (Racing Kings)
 inline bool Position::is_race_draw() const {
-  return is_race_win() && is_race_loss();
+  return rank_of(square<KING>(sideToMove)) == RANK_8
+        && rank_of(square<KING>(~sideToMove)) == RANK_8;
 }
 
 // Loss if king is on the eighth rank (Racing Kings)
 inline bool Position::is_race_loss() const {
-  return (sideToMove == WHITE || rank_of(square<KING>(sideToMove)) < RANK_7) &&
-         rank_of(square<KING>(~sideToMove)) == RANK_8;
+  return rank_of(square<KING>(~sideToMove)) == RANK_8
+        && rank_of(square<KING>(sideToMove)) < (sideToMove == WHITE ? RANK_8 : RANK_7);
 }
 #endif
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -272,8 +272,9 @@ void MainThread::search() {
           score = -VALUE_MATE;
 #endif
 #ifdef RACE
-      if (rootPos.is_race() && rootPos.is_race_loss())
-          score = -VALUE_MATE;
+      if (rootPos.is_race())
+          score =  rootPos.is_race_draw() ? VALUE_DRAW
+                 : rootPos.is_race_loss() ? -VALUE_MATE : VALUE_MATE;
 #endif
 #ifdef HORDE
       if (rootPos.is_horde() && rootPos.is_horde_loss())


### PR DESCRIPTION
In final positions like "K6k/8/8/8/8/8/8/8 w - - 0 1" or "K7/7k/8/8/8/8/8/8 w - - 0 1" the evaluation was incorrect. As far as I can judge this did not affect results in non-final positions, so it is just a minor bugfix.