### PR TITLE
Tweak Three-Check check count bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -180,9 +180,9 @@ namespace {
 #ifdef THREECHECK
   const Score ChecksGivenBonus[CHECKS_NB] = {
       S(0, 0),
-      S(2 * PawnValueMg, 2 * PawnValueEg),
-      S(5 * PawnValueMg, 4 * PawnValueEg),
-      S(9 * PawnValueMg, 9 * PawnValueEg)
+      S(472, 369),
+      S(1980, 1159),
+      S(0, 0)
   };
 #endif
 


### PR DESCRIPTION
Three of the four values aren't that much different after tuning, whereas the bonus for two checks in the middlegame doubled.

ELO: 58.93 +-21.3 (95%) LOS: 100.0%
Total: 1000 W: 562 L: 394 D: 44