### PR TITLE
Adjust SEE for Antichess

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -224,6 +224,9 @@ enum Piece {
 const Piece Pieces[] = { W_PAWN, W_KNIGHT, W_BISHOP, W_ROOK, W_QUEEN, W_KING,
                          B_PAWN, B_KNIGHT, B_BISHOP, B_ROOK, B_QUEEN, B_KING };
 extern Value PieceValue[PHASE_NB][PIECE_NB];
+#ifdef ANTI
+extern Value PieceValueAnti[PHASE_NB][PIECE_NB];
+#endif
 
 enum Depth {
 


### PR DESCRIPTION
Use Antichess piece values, take into account that captures are mandatory,
and do not stop before king captures to get a more suitable SEE.

ELO: 34.51 +-19.5 (95%) LOS: 100.0%
Total: 1000 W: 455 L: 356 D: 189