### PR TITLE
Fix bug in Atomic SEE + evaluation tweaks

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -190,6 +190,11 @@ namespace {
   const Score AntiPieceScore      = S(-500, -500);
 #endif
 
+#ifdef ATOMIC
+  Score CloseEnemiesAtomic = S( 17,   0);
+  Score PawnBonusAtomic    = S(200, 199);
+#endif
+
   // PassedFile[File] contains a bonus according to the file of a passed pawn
   const Score PassedFile[FILE_NB] = {
     S(  9, 10), S( 2, 10), S( 1, -8), S(-20,-12),
@@ -546,6 +551,11 @@ namespace {
     b =  (Us == WHITE ? b << 4 : b >> 4)
        | (b & ei.attackedBy2[Them] & ~ei.attackedBy[Us][PAWN]);
 
+#ifdef ATOMIC
+    if (pos.is_atomic())
+        score -= CloseEnemiesAtomic * popcount(b);
+    else
+#endif
     score -= CloseEnemies * popcount(b);
 
     if (DoTrace)
@@ -1199,7 +1209,7 @@ Value Eval::evaluate(const Position& pos) {
 #endif
 #ifdef ATOMIC
   if (pos.is_atomic())
-      score -= make_score(pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK),pos.non_pawn_material(WHITE) - pos.non_pawn_material(BLACK))/4;
+      score += (pos.count<PAWN>(WHITE) - pos.count<PAWN>(BLACK)) * PawnBonusAtomic;
 #endif
 
   // Evaluate scale factor for the winning side

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1125,9 +1125,6 @@ moves_loop: // When in check search starts from here
 #ifdef ANTI
               if (pos.is_anti()) {} else
 #endif
-#ifdef ATOMIC
-              if (pos.is_atomic()) {} else
-#endif
 #ifdef RACE
               if (pos.is_race()) {} else
 #endif


### PR DESCRIPTION
The Atomic SEE score of quiet moves in was meaningless, because it was assumed that all moves given to the SEE are captures and hence cause an explosion. This is fixed by the first commit, which yields a big Elo gain:
ELO: 139.81 +-21.4 (95%) LOS: 100.0%
Total: 1000 W: 625 L: 243 D: 132

The second commit replaces the non-pawn material penalty by a pawn bonus, which could be replaced in a non-functional patch if we decide to introduce Atomic piece values. Furthermore, the CloseEnemies penalty is tweaked for Atomic variant.
ELO: 47.90 +-19.6 (95%) LOS: 100.0%
Total: 1000 W: 475 L: 338 D: 187

The third commit reactivates SEE pruning in Atomic chess and builds upon the fix of the SEE bug. So SEE pruning can now be tuned for Atomic chess.
ELO: -2.43 +-18.7 (95%) LOS: 40.0%
Total: 1000 W: 375 L: 382 D: 243