### PR TITLE
Fix #55

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -82,7 +82,7 @@ namespace {
 #ifdef ANTI
     if (pos.is_anti())
     {
-        if (Type == CAPTURES || Type == NON_EVASIONS)
+        if (Type == QUIETS || Type == CAPTURES || Type == NON_EVASIONS)
         {
             *moveList++ = make<PROMOTION>(to - Delta, to, QUEEN);
             *moveList++ = make<PROMOTION>(to - Delta, to, ROOK);

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -222,9 +222,6 @@ Move MovePicker::next_move() {
 
       ++stage;
       move = ss->killers[0];  // First killer move
-#ifdef ANTI
-      if (pos.is_anti() && pos.can_capture()) {} else
-#endif
       if (    move != MOVE_NONE
           &&  move != ttMove
           &&  pos.pseudo_legal(move)
@@ -234,9 +231,6 @@ Move MovePicker::next_move() {
   case KILLERS:
       ++stage;
       move = ss->killers[1]; // Second killer move
-#ifdef ANTI
-      if (pos.is_anti() && pos.can_capture()) {} else
-#endif
       if (    move != MOVE_NONE
           &&  move != ttMove
           &&  pos.pseudo_legal(move)
@@ -246,9 +240,6 @@ Move MovePicker::next_move() {
   case COUNTERMOVE:
       ++stage;
       move = countermove;
-#ifdef ANTI
-      if (pos.is_anti() && pos.can_capture()) {} else
-#endif
       if (    move != MOVE_NONE
           &&  move != ttMove
           &&  move != ss->killers[0]

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -787,6 +787,10 @@ bool Position::pseudo_legal(const Move m) const {
       }
   }
 #endif
+#ifdef ANTI
+  if (is_anti() && !capture(m) && can_capture())
+      return false;
+#endif
 
   // Use a slower but simpler function for uncommon cases
   if (type_of(m) != NORMAL)

--- a/src/types.h
+++ b/src/types.h
@@ -454,7 +454,7 @@ template<MoveType T>
 inline Move make(Square from, Square to, PieceType pt = KNIGHT) {
 #ifdef ANTI
   if (pt == KING)
-      return Move((1 << 16) | (T + ((pt - KNIGHT) << 12) + (from << 6) + to));
+      return Move((1 << 16) | (T + (from << 6) + to));
 #endif
   return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);
 }


### PR DESCRIPTION
KING-KNIGHT=5 has 3 bits, but only 2 bits are used for the promotion piece type, so it could change the move type, which is stored in front of it. This started to cause problems with 057d710, which changed the "Move make" function.

By the way, I had tested 77bc75b before the merge of the upstream changes and thought that retesting is not necessary, because the changes were supposed to be non-functional (in standard chess).