### PR TITLE
Add KOTH to UCI_Variant option

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -116,7 +116,7 @@ static std::vector<std::string> variants = {"chess"
 #ifdef HORDE
 ,"horde"
 #endif
-#ifdef KINGOFTHEHILL
+#ifdef KOTH
 ,"kingofthehill"
 #endif
 #ifdef RACE


### PR DESCRIPTION
Correct the argument of a preprocessor directive that caused King of the Hill to not be added as an option.