### PR TITLE
Introduce horde piece values

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -955,9 +955,7 @@ namespace {
 #ifdef HORDE
     if (pos.is_horde() && pos.is_horde_color(Us))
     {
-        weight += pos.non_pawn_material(Them) / PawnValueMg;
-        bonus = bonus * weight * weight / 200;
-        return make_score(bonus, bonus) + make_score(pos.non_pawn_material(Them) * 2 / 9, 0);
+        return make_score(bonus * weight * weight / 200, 0);
     }
 #endif
 #ifdef KOTH

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -47,8 +47,8 @@ Value PieceValue[VARIANT_NB][PHASE_NB][PIECE_NB] = {
 #endif
 #ifdef HORDE
 {
-  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
-  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg },
+  { VALUE_ZERO, PawnValueMgHorde, KnightValueMgHorde, BishopValueMgHorde, RookValueMgHorde, QueenValueMgHorde, KingValueMgHorde },
+  { VALUE_ZERO, PawnValueEgHorde, KnightValueEgHorde, BishopValueEgHorde, RookValueEgHorde, QueenValueEgHorde, KingValueEgHorde },
 },
 #endif
 #ifdef KOTH

--- a/src/types.h
+++ b/src/types.h
@@ -263,6 +263,14 @@ enum Value : int {
   QueenValueMgAnti  = -936,  QueenValueEgAnti  = -829,
   KingValueMgAnti   = -230,  KingValueEgAnti   = -168,
 #endif
+#ifdef HORDE
+  PawnValueMgHorde   = 350,   PawnValueEgHorde   = 350,
+  KnightValueMgHorde = 753,   KnightValueEgHorde = 832,
+  BishopValueMgHorde = 826,   BishopValueEgHorde = 897,
+  RookValueMgHorde   = 1285,  RookValueEgHorde   = 1371,
+  QueenValueMgHorde  = 2513,  QueenValueEgHorde  = 2650,
+  KingValueMgHorde   = 1000,  KingValueEgHorde   = 1000,
+#endif
 
   MidgameLimit  = 15258, EndgameLimit  = 3915
 };


### PR DESCRIPTION
Introduce horde piece values and remove nonPawnMaterial from the horde evaluation function to prepare for tuning. 

ELO: 92.46 +-22.0 (95%) LOS: 100.0%
Total: 1000 W: 619 L: 359 D: 22