### PR TITLE
Implement Crazyhouse

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -178,6 +178,8 @@ public:
   void add_to_hand(Color c, PieceType pt);
   void remove_from_hand(Color c, PieceType pt);
   bool is_promoted(Square s) const;
+  void drop_piece(Piece pc, Square s);
+  void undrop_piece(Piece pc, Square s);
 #endif
 #ifdef KOTH
   bool is_koth() const;
@@ -277,6 +279,10 @@ inline Piece Position::piece_on(Square s) const {
 }
 
 inline Piece Position::moved_piece(Move m) const {
+#ifdef CRAZYHOUSE
+  if (type_of(m) == DROP)
+      return dropped_piece(m);
+#endif
   return board[from_sq(m)];
 }
 
@@ -690,5 +696,18 @@ inline void Position::move_piece(Piece pc, Square from, Square to) {
   index[to] = index[from];
   pieceList[pc][index[to]] = to;
 }
+
+#ifdef CRAZYHOUSE
+inline void Position::drop_piece(Piece pc, Square s) {
+  put_piece(pc, s);
+  pieceCountInHand[color_of(pc)][type_of(pc)]--;
+}
+
+inline void Position::undrop_piece(Piece pc, Square s) {
+  remove_piece(pc, s);
+  board[s] = NO_PIECE;
+  pieceCountInHand[color_of(pc)][type_of(pc)]++;
+}
+#endif
 
 #endif // #ifndef POSITION_H_INCLUDED

--- a/src/types.h
+++ b/src/types.h
@@ -184,6 +184,9 @@ enum MoveType {
   PROMOTION = 1 << 14,
   ENPASSANT = 2 << 14,
   CASTLING  = 3 << 14
+#ifdef CRAZYHOUSE
+  ,DROP = 1 << 17
+#endif
 };
 
 enum Color {
@@ -504,6 +507,10 @@ inline Square pawn_push(Color c) {
 }
 
 inline Square from_sq(Move m) {
+#ifdef CRAZYHOUSE
+  if (m & DROP)
+      return SQ_NONE;
+#endif
   return Square((m >> 6) & 0x3F);
 }
 
@@ -512,6 +519,10 @@ inline Square to_sq(Move m) {
 }
 
 inline MoveType type_of(Move m) {
+#ifdef CRAZYHOUSE
+  if (m & DROP)
+      return DROP;
+#endif
   return MoveType(m & (3 << 14));
 }
 
@@ -535,6 +546,16 @@ inline Move make(Square from, Square to, PieceType pt = KNIGHT) {
 #endif
   return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);
 }
+
+#ifdef CRAZYHOUSE
+inline Move make_drop(Square to, Piece pc) {
+  return Move(DROP + (pc << 18) + to);
+}
+
+inline Piece dropped_piece(Move m) {
+  return Piece((m >> 18) & 15);
+}
+#endif
 
 inline bool is_ok(Move m) {
   return from_sq(m) != to_sq(m); // Catch MOVE_NULL and MOVE_NONE

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -333,7 +333,11 @@ string UCI::move(Move m, bool chess960) {
   if (type_of(m) == CASTLING && !chess960)
       to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
 
+#ifdef CRAZYHOUSE
+  string move = ((type_of(m) == DROP) ? std::string{" PNBRQK  pnbrqk "[dropped_piece(m)], '@'} : UCI::square(from)) + UCI::square(to);
+#else
   string move = UCI::square(from) + UCI::square(to);
+#endif
 
   if (type_of(m) == PROMOTION)
       move += " pnbrqk"[promotion_type(m)];


### PR DESCRIPTION
All crazyhouse rules should be implemented and perft results seem to be correct.

Drops are printed as piece@square, e.g., `P@e5`. In the move encoding 5 additional bits are used for drops: 1 for the move type DROP, and 4 for the dropped piece.

Known issues:
- so far hash collisions are likely, because the pieces in hand are not taken account of in the calculation of hash keys.
- movepicking should probably be improved
- evaluation does not take account of pieces in hand

In summary, except for the rules nothing has been adapted for crazyhouse yet. Further validation of the move generation should be performed, especially to test for the handling of special rules like the capturing of promoted pieces and subsequent drops.