### PR TITLE
Fix parsing of crazyhouse FEN

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -248,7 +248,7 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
 #ifdef CRAZYHOUSE
       // Set flag for promoted pieces
       else if (is_house() && token == '~')
-          promotedPieces |= sq;
+          promotedPieces |= sq - Square(1);
       // Stop before pieces in hand
       else if (is_house() && token == '[')
           break;


### PR DESCRIPTION
The flags for promoted pieces were shifted when parsing FENs.