### PR TITLE
Fix crazyhouse segmentation faults

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -102,7 +102,11 @@ const bool Is64Bit = false;
 typedef uint64_t Key;
 typedef uint64_t Bitboard;
 
+#ifdef CRAZYHOUSE
+const int MAX_MOVES = 512;
+#else
 const int MAX_MOVES = 256;
+#endif
 const int MAX_PLY   = 128;
 
 enum Variant {


### PR DESCRIPTION
Increase maximum number of moves from 256 to 512 to avoid exceeding the limit in crazyhouse due to piece drops.

I do not know if a non-trivial proven upper bound is known, but I think 512 should be safe.