### PR TITLE
Tweak piece values

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -647,10 +647,6 @@ Phase Position::game_phase() const {
   if (is_horde())
       npm = 2 * st->nonPawnMaterial[is_horde_color(WHITE) ? BLACK : WHITE];
 #endif
-#ifdef ATOMIC
-  if (is_atomic())
-      npm += npm;
-#endif
 
   npm = std::max(EndgameLimit, std::min(npm, MidgameLimit));
 

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -59,8 +59,8 @@ Value PieceValue[VARIANT_NB][PHASE_NB][PIECE_NB] = {
 #endif
 #ifdef RACE
 {
-  { VALUE_ZERO, PawnValueMg, KnightValueMg, BishopValueMg, RookValueMg, QueenValueMg },
-  { VALUE_ZERO, PawnValueEg, KnightValueEg, BishopValueEg, RookValueEg, QueenValueEg },
+  { VALUE_ZERO, VALUE_ZERO, KnightValueMgRace, BishopValueMgRace, RookValueMgRace, QueenValueMgRace },
+  { VALUE_ZERO, VALUE_ZERO, KnightValueEgRace, BishopValueEgRace, RookValueEgRace, QueenValueEgRace },
 },
 #endif
 #ifdef RELAY

--- a/src/types.h
+++ b/src/types.h
@@ -271,11 +271,11 @@ enum Value : int {
   KingValueMgAnti   = -230,  KingValueEgAnti   = -168,
 #endif
 #ifdef ATOMIC
-  PawnValueMgAtomic   = 421,   PawnValueEgAtomic   = 477,
-  KnightValueMgAtomic = 472,   KnightValueEgAtomic = 779,
-  BishopValueMgAtomic = 667,   BishopValueEgAtomic = 912,
-  RookValueMgAtomic   = 877,   RookValueEgAtomic   = 1477,
-  QueenValueMgAtomic  = 2203,  QueenValueEgAtomic  = 2815,
+  PawnValueMgAtomic   = 366,   PawnValueEgAtomic   = 445,
+  KnightValueMgAtomic = 519,   KnightValueEgAtomic = 787,
+  BishopValueMgAtomic = 655,   BishopValueEgAtomic = 876,
+  RookValueMgAtomic   = 887,   RookValueEgAtomic   = 1356,
+  QueenValueMgAtomic  = 2027,  QueenValueEgAtomic  = 2915,
 #endif
 #ifdef CRAZYHOUSE
   PawnValueMgHouse   = 300,   PawnValueEgHouse   = 300,

--- a/src/types.h
+++ b/src/types.h
@@ -278,11 +278,11 @@ enum Value : int {
   QueenValueMgAtomic  = 2027,  QueenValueEgAtomic  = 2915,
 #endif
 #ifdef CRAZYHOUSE
-  PawnValueMgHouse   = 300,   PawnValueEgHouse   = 300,
-  KnightValueMgHouse = 600,   KnightValueEgHouse = 600,
-  BishopValueMgHouse = 600,   BishopValueEgHouse = 600,
-  RookValueMgHouse   = 600,   RookValueEgHouse   = 600,
-  QueenValueMgHouse  = 1200,  QueenValueEgHouse  = 1200,
+  PawnValueMgHouse   = 251,   PawnValueEgHouse   = 271,
+  KnightValueMgHouse = 515,   KnightValueEgHouse = 615,
+  BishopValueMgHouse = 598,   BishopValueEgHouse = 622,
+  RookValueMgHouse   = 695,   RookValueEgHouse   = 732,
+  QueenValueMgHouse  = 1014,  QueenValueEgHouse  = 1139,
 #endif
 #ifdef HORDE
   PawnValueMgHorde   = 406,   PawnValueEgHorde   = 427,

--- a/src/types.h
+++ b/src/types.h
@@ -292,6 +292,12 @@ enum Value : int {
   QueenValueMgHorde  = 2777,  QueenValueEgHorde  = 3182,
   KingValueMgHorde   = 2041,  KingValueEgHorde   = 975,
 #endif
+#ifdef RACE
+  KnightValueMgRace = 720,   KnightValueEgRace = 801,
+  BishopValueMgRace = 904,   BishopValueEgRace = 929,
+  RookValueMgRace   = 1265,  RookValueEgRace  = 1731,
+  QueenValueMgRace  = 2198,  QueenValueEgRace = 2226,
+#endif
 #ifdef THREECHECK
   PawnValueMgThreeCheck   = 181,   PawnValueEgThreeCheck   = 245,
   KnightValueMgThreeCheck = 691,   KnightValueEgThreeCheck = 850,


### PR DESCRIPTION
Tweak racing kings, atomic, and crazyhouse piece values and simplify calculation of game phase in the case of atomic chess.