### PR TITLE
Remove penalty for weak pieces in atomic chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -640,6 +640,11 @@ namespace {
         score += LooseEnemies;
 
     // Non-pawn enemies attacked by a pawn
+#ifdef ATOMIC
+    if (pos.is_atomic())
+        weak = 0;
+    else
+#endif
     weak = (pos.pieces(Them) ^ pos.pieces(Them, PAWN)) & ei.attackedBy[Us][PAWN];
 
     if (weak)


### PR DESCRIPTION
Pieces attacked by pawns are not necessarily hanging in atomic chess.

LLR: 3.02 (-2.94,2.94) [0.00,20.00]
Total: 412 W: 164 L: 114 D: 134