### PR TITLE
Tweak atomic piece values and passed pawn bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -840,14 +840,6 @@ namespace {
             }
             else
 #endif
-#ifdef ATOMIC
-            if (pos.is_atomic())
-            {
-                // Adjust bonus based on proximity to promotion
-                ebonus += relative_rank(Us, s) * 5 * rr;
-            }
-            else
-#endif
 #ifdef ANTI
             if (pos.is_anti())
             {

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -177,6 +177,12 @@ namespace {
     { V(5), V( 5), V(31), V(73), V(166), V(252) },
     { V(7), V(14), V(38), V(73), V(166), V(252) }
   };
+#ifdef ATOMIC
+  const Value PassedAtomic[][RANK_NB] = {
+    { V(106), V(124), V(147), V(165), V(169), V(177) },
+    { V(103), V(118), V(148), V(155), V(142), V(153) }
+  };
+#endif
 
 #ifdef THREECHECK
   const Score ChecksGivenBonus[CHECKS_NB] = {
@@ -814,6 +820,10 @@ namespace {
         int rr = r * (r - 1);
 
         Value mbonus = Passed[MG][r], ebonus = Passed[EG][r];
+#ifdef ATOMIC
+        if (pos.is_atomic())
+            mbonus = PassedAtomic[MG][r], ebonus = PassedAtomic[EG][r];
+#endif
 
         if (rr)
         {

--- a/src/types.h
+++ b/src/types.h
@@ -271,11 +271,11 @@ enum Value : int {
   KingValueMgAnti   = -230,  KingValueEgAnti   = -168,
 #endif
 #ifdef ATOMIC
-  PawnValueMgAtomic   = 366,   PawnValueEgAtomic   = 445,
-  KnightValueMgAtomic = 519,   KnightValueEgAtomic = 787,
-  BishopValueMgAtomic = 655,   BishopValueEgAtomic = 876,
-  RookValueMgAtomic   = 887,   RookValueEgAtomic   = 1356,
-  QueenValueMgAtomic  = 2027,  QueenValueEgAtomic  = 2915,
+  PawnValueMgAtomic   = 332,   PawnValueEgAtomic   = 438,
+  KnightValueMgAtomic = 478,   KnightValueEgAtomic = 736,
+  BishopValueMgAtomic = 614,   BishopValueEgAtomic = 823,
+  RookValueMgAtomic   = 957,   RookValueEgAtomic   = 1278,
+  QueenValueMgAtomic  = 1904,  QueenValueEgAtomic  = 2918,
 #endif
 #ifdef CRAZYHOUSE
   PawnValueMgHouse   = 251,   PawnValueEgHouse   = 271,


### PR DESCRIPTION
The value of passed pawns does not depend as much on its rank as in standard chess. Tweak piece values to adjust to the new passed pawn bonuses.