### PR TITLE
Print FEN of starting position after UCI_Variant is set

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -140,11 +140,11 @@ enum Variant {
 
 //static const constexpr char* variants[] doesn't play nicely with uci.h
 static std::vector<std::string> variants = {"chess"
-#ifdef ATOMIC
-,"atomic"
-#endif
 #ifdef ANTI
 ,"giveaway"
+#endif
+#ifdef ATOMIC
+,"atomic"
 #endif
 #ifdef CRAZYHOUSE
 ,"crazyhouse"


### PR DESCRIPTION
Print the FEN of the starting position after the `UCI_Variant` option is set as proposed in #109 and no longer send it in response to the `position` command.