### PR TITLE
Tweak move ordering of captures in antichess

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -133,9 +133,16 @@ void MovePicker::score<CAPTURES>() {
   // badCaptures[] array, but instead of doing it now we delay until the move
   // has been picked up, saving some SEE calls in case we get a cutoff.
   for (auto& m : *this)
+#ifdef ANTI
+      if (pos.is_anti())
+          m.value = PieceValue[pos.variant()][MG][pos.piece_on(to_sq(m))]
+                   - Value(50 * relative_rank(pos.side_to_move(), to_sq(m)));
+      else
+#endif
 #ifdef RACE
       if (pos.is_race())
-          m.value = PieceValue[pos.variant()][MG][pos.piece_on(to_sq(m))] - Value(200 * relative_rank(BLACK, to_sq(m)));
+          m.value = PieceValue[pos.variant()][MG][pos.piece_on(to_sq(m))]
+                   - Value(200 * relative_rank(BLACK, to_sq(m)));
       else
 #endif
       m.value =  PieceValue[pos.variant()][MG][pos.piece_on(to_sq(m))]


### PR DESCRIPTION
LLR: 3.06 (-2.94,2.94) [0.00,20.00]
Total: 802 W: 249 L: 194 D: 359