### PR TITLE
Add support for subvariants

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -398,7 +398,7 @@ namespace {
             while (b)
                 *moveList++ = make_move(ksq, pop_lsb(&b));
         }
-        if (pos.can_capture())
+        if (pos.is_suicide() || pos.can_capture())
             return moveList;
     }
     else

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -252,7 +252,18 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
   std::memset(si, 0, sizeof(StateInfo));
   std::fill_n(&pieceList[0][0], sizeof(pieceList) / sizeof(Square), SQ_NONE);
   st = si;
-  var = v;
+  subvar = v;
+  if (v < VARIANT_NB)
+      var = v;
+  else
+      switch(v)
+      {
+      case SUICIDE_VARIANT:
+          var = ANTI_VARIANT;
+          break;
+      default:
+          assert(false);
+      }
 
   ss >> std::noskipws;
 

--- a/src/position.h
+++ b/src/position.h
@@ -164,6 +164,7 @@ public:
   int game_ply() const;
   bool is_chess960() const;
   Variant variant() const;
+  Variant subvariant() const;
 #ifdef ATOMIC
   bool is_atomic() const;
   bool is_atomic_win() const;
@@ -207,6 +208,8 @@ public:
 #endif
 #ifdef ANTI
   bool is_anti() const;
+  bool is_suicide() const;
+  Value suicide_stalemate(int ply, Value draw) const;
   bool is_anti_win() const;
   bool is_anti_loss() const;
   bool can_capture() const;
@@ -263,6 +266,7 @@ private:
   StateInfo* st;
   bool chess960;
   Variant var;
+  Variant subvar;
 
 };
 
@@ -518,6 +522,19 @@ inline bool Position::is_anti() const {
   return var == ANTI_VARIANT;
 }
 
+inline bool Position::is_suicide() const {
+  return subvar == SUICIDE_VARIANT;
+}
+
+inline Value Position::suicide_stalemate(int ply, Value draw) const {
+  int balance = popcount(pieces(sideToMove)) - popcount(pieces(~sideToMove));
+  if (balance > 0)
+      return mated_in(ply);
+  if (balance < 0)
+      return mate_in(ply + 1);
+  return draw;
+}
+
 inline bool Position::is_anti_loss() const {
   return count<ALL_PIECES>(~sideToMove) == 0;
 }
@@ -625,6 +642,10 @@ inline bool Position::is_chess960() const {
 
 inline Variant Position::variant() const {
   return var;
+}
+
+inline Variant Position::subvariant() const {
+  return subvar;
 }
 
 inline bool Position::capture_or_promotion(Move m) const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1315,7 +1315,9 @@ moves_loop: // When in check search starts from here
 #endif
 #ifdef ANTI
         if (pos.is_anti())
-            bestValue = excludedMove ? alpha : mate_in(ss->ply+1);
+            bestValue = excludedMove ? alpha
+            : pos.is_suicide() ? pos.suicide_stalemate(ss->ply, DrawValue[pos.side_to_move()])
+            : mate_in(ss->ply+1);
         else
 #endif
         bestValue = excludedMove ? alpha

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -214,7 +214,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->tbHits = 0;
       th->rootDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
-      th->rootPos.set(pos.fen(), pos.is_chess960(), pos.variant(), &setupStates->back(), th);
+      th->rootPos.set(pos.fen(), pos.is_chess960(), pos.subvariant(), &setupStates->back(), th);
   }
 
   setupStates->back() = tmp; // Restore st->previous, cleared by Position::set()

--- a/src/types.h
+++ b/src/types.h
@@ -110,6 +110,7 @@ const int MAX_MOVES = 256;
 const int MAX_PLY   = 128;
 
 enum Variant {
+  //main variants
   CHESS_VARIANT,
 #ifdef ANTI
   ANTI_VARIANT,
@@ -135,34 +136,46 @@ enum Variant {
 #ifdef THREECHECK
   THREECHECK_VARIANT,
 #endif
-  VARIANT_NB
+  VARIANT_NB,
+  LAST_VARIANT = VARIANT_NB - 1,
+  //subvariants
+#ifdef ANTI
+  SUICIDE_VARIANT,
+#endif
+  SUBVARIANT_NB
 };
 
 //static const constexpr char* variants[] doesn't play nicely with uci.h
-static std::vector<std::string> variants = {"chess"
+static std::vector<std::string> variants = {
+//main variants
+"chess",
 #ifdef ANTI
-,"giveaway"
+"giveaway",
 #endif
 #ifdef ATOMIC
-,"atomic"
+"atomic",
 #endif
 #ifdef CRAZYHOUSE
-,"crazyhouse"
+"crazyhouse",
 #endif
 #ifdef HORDE
-,"horde"
+"horde",
 #endif
 #ifdef KOTH
-,"kingofthehill"
+"kingofthehill",
 #endif
 #ifdef RACE
-,"racingkings"
+"racingkings",
 #endif
 #ifdef RELAY
-,"relay"
+"relay",
 #endif
 #ifdef THREECHECK
-,"threecheck"
+"threecheck",
+#endif
+// subvariants
+#ifdef ANTI
+"suicide",
 #endif
 };
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -38,38 +38,41 @@ extern void benchmark(const Position& pos, istream& is);
 namespace {
 
   Variant variant_from_name(string s) {
-      for (Variant v = CHESS_VARIANT; v < VARIANT_NB; ++v)
+      for (Variant v = CHESS_VARIANT; v < SUBVARIANT_NB; ++v)
           if (variants[v] == s)
               return v;
       return CHESS_VARIANT;
   }
 
   // FEN strings of the initial positions
-  const string StartFENs[VARIANT_NB] = {
-  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  const string StartFENs[SUBVARIANT_NB] = {
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #ifdef ANTI
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef ATOMIC
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef CRAZYHOUSE
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1",
 #endif
 #ifdef HORDE
-  ,"rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1"
+  "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1",
 #endif
 #ifdef KOTH
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef RACE
-  ,"8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
+  "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1",
 #endif
 #ifdef RELAY
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef THREECHECK
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1",
+#endif
+#ifdef ANTI
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1",
 #endif
   };
 


### PR DESCRIPTION
Add the possibility of including subvariants that can share code with their parent variant. This is the simplest way I could find to implement subvariants like suicide chess without having to add a lot of code. 

By way of example, implement suicide chess (as requested in #110) as a subvariant of giveaway chess.

Feedback is very welcome.