### PR TITLE
Fully support atomic tablebases (fixes #123)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]) {
   Search::init();
   Pawns::init();
   Threads.init();
-  Tablebases::init(Options["SyzygyPath"]);
+  Tablebases::init(Options["SyzygyPath"], CHESS_VARIANT);
   TT.resize(Options["Hash"]);
 
   UCI::loop(argc, argv);

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -46,7 +46,7 @@ enum ProbeState {
 
 extern int MaxCardinality;
 
-void init(const std::string& paths);
+void init(const std::string& paths, Variant variant);
 WDLScore probe_wdl(Position& pos, ProbeState* result);
 int probe_dtz(Position& pos, ProbeState* result);
 bool root_probe(Position& pos, Search::RootMoves& rootMoves, Value& score);

--- a/src/uci.h
+++ b/src/uci.h
@@ -76,6 +76,7 @@ std::string square(Square s);
 std::string move(Move m, bool chess960);
 std::string pv(const Position& pos, Depth depth, Value alpha, Value beta);
 Move to_move(const Position& pos, std::string& str);
+Variant variant_from_name(const std::string& str);
 
 } // namespace UCI
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -40,7 +40,7 @@ void on_clear_hash(const Option&) { Search::clear(); }
 void on_hash_size(const Option& o) { TT.resize(o); }
 void on_logger(const Option& o) { start_logger(o); }
 void on_threads(const Option&) { Threads.read_uci_options(); }
-void on_tb_path(const Option& o) { Tablebases::init(o); }
+void on_tb_path(const Option& o) { Tablebases::init(o, UCI::variant_from_name(Options["UCI_Variant"])); }
 
 
 /// Our case insensitive less() function as required by UCI protocol


### PR DESCRIPTION
The problem:

* Atomic tablebase probe results were incorrect or crashing in endgames where no side had unique pieces other than kings, for example KQQvK as reported in #123.

The solution (based on Ronald de Mans [code that has been stripped from Stockfish](https://github.com/syzygy1/tb/commit/2e79be9cb859159c9f76f45069b21011d013f9c9)):

* This type of endgame (`enc_type == 2` aka `!hasUniquePieces`) has to be decoded differently [(via)](https://github.com/syzygy1/tb/commit/2e79be9cb859159c9f76f45069b21011d013f9c9#diff-ec837388631b3d6e183e2b5d99d70468L855). 
* The number of possible king configurations is different [(via)](https://github.com/syzygy1/tb/commit/2e79be9cb859159c9f76f45069b21011d013f9c9#diff-ec837388631b3d6e183e2b5d99d70468L1025).
* The latter is decided without a position object around, but we need to know the variant. Make `variant` a property of `WdlEntry`.
* Now we need to take care and reinitialize syzygy tables whenever the variant changes.

As a bonus:

* Now that we pass the variant down, it is trivial to handle the different file suffixes. I use `nullptr` to indicate that no tables for that variant have been generated and no file extension has been agreed upon.

---

Support for suicide/giveaway tables can also be based on https://github.com/syzygy1/tb/commit/2e79be9cb859159c9f76f45069b21011d013f9c9, but is going to require more changes than atomic chess.