### PR TITLE
Fix repetition detection for crazyhouse

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1868,7 +1868,11 @@ bool Position::is_draw() const {
       return true;
 
   StateInfo* stp = st;
+#ifdef CRAZYHOUSE
+  for (int i = 2, rep = 1, e = is_house() ? st->pliesFromNull : std::min(st->rule50, st->pliesFromNull); i <= e; i += 2)
+#else
   for (int i = 2, rep = 1, e = std::min(st->rule50, st->pliesFromNull); i <= e; i += 2)
+#endif
   {
       stp = stp->previous->previous;
 


### PR DESCRIPTION
In crazyhouse repetitions can also occur after captures, since, in contrast to variants without piece drops, captures do not irreversibly change the position. The same applies for pawn advances and promotions.

A tuning session got stuck in the position `7k/1pp1p1pp/4q3/p3N2q/3PBP2/8/PNPBBPPp/1R2K2R[RPPrbnnp] b - - 0 45`, where Stockfish repeatedly plays the moves `R@g1 R@f1 g1h1 f1h1`, because repetition detection stops at captures (or more generally, moves that reset the 50 moves rule counter).