### PR TITLE
Subvariants

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -398,7 +398,7 @@ namespace {
             while (b)
                 *moveList++ = make_move(ksq, pop_lsb(&b));
         }
-        if (pos.can_capture())
+        if (pos.is_suicide() || pos.can_capture())
             return moveList;
     }
     else

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -252,7 +252,15 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
   std::memset(si, 0, sizeof(StateInfo));
   std::fill_n(&pieceList[0][0], sizeof(pieceList) / sizeof(Square), SQ_NONE);
   st = si;
-  var = v;
+  subvar = v;
+  if (v < VARIANT_NB)
+      var = v;
+  else
+      switch(v)
+      {
+      default:
+          assert(false);
+      }
 
   ss >> std::noskipws;
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -258,6 +258,11 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
   else
       switch(v)
       {
+#ifdef ANTI //suicide
+      case SUICIDE_VARIANT:
+          var = ANTI_VARIANT;
+          break;
+#endif
       default:
           assert(false);
       }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -263,6 +263,11 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
           var = ANTI_VARIANT;
           break;
 #endif
+#ifdef CRAZYHOUSE //loop
+      case LOOP_VARIANT:
+          var = CRAZYHOUSE_VARIANT;
+          break;
+#endif
       default:
           assert(false);
       }
@@ -285,7 +290,7 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
       }
 #ifdef CRAZYHOUSE
       // Set flag for promoted pieces
-      else if (is_house() && token == '~')
+      else if (is_house() && !is_loop() && token == '~')
           promotedPieces |= sq - Square(1);
       // Stop before pieces in hand
       else if (is_house() && token == '[')
@@ -1388,7 +1393,7 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
           remove_piece(pc, to);
           put_piece(promotion, to);
 #ifdef CRAZYHOUSE
-          if (is_house())
+          if (is_house() && !is_loop())
               promotedPieces = promotedPieces | to;
 #endif
 

--- a/src/position.h
+++ b/src/position.h
@@ -164,6 +164,7 @@ public:
   int game_ply() const;
   bool is_chess960() const;
   Variant variant() const;
+  Variant subvariant() const;
 #ifdef ATOMIC
   bool is_atomic() const;
   bool is_atomic_win() const;
@@ -263,6 +264,7 @@ private:
   StateInfo* st;
   bool chess960;
   Variant var;
+  Variant subvar;
 
 };
 
@@ -625,6 +627,10 @@ inline bool Position::is_chess960() const {
 
 inline Variant Position::variant() const {
   return var;
+}
+
+inline Variant Position::subvariant() const {
+    return subvar;
 }
 
 inline bool Position::capture_or_promotion(Move m) const {

--- a/src/position.h
+++ b/src/position.h
@@ -177,6 +177,7 @@ public:
 #endif
 #ifdef CRAZYHOUSE
   bool is_house() const;
+  bool is_loop() const;
   int count_in_hand(Color c, PieceType pt) const;
   void add_to_hand(Color c, PieceType pt);
   void remove_from_hand(Color c, PieceType pt);
@@ -561,6 +562,10 @@ inline bool Position::can_capture() const {
 #ifdef CRAZYHOUSE
 inline bool Position::is_house() const {
   return var == CRAZYHOUSE_VARIANT;
+}
+
+inline bool Position::is_loop() const {
+  return subvar == LOOP_VARIANT;
 }
 
 inline int Position::count_in_hand(Color c, PieceType pt) const {

--- a/src/position.h
+++ b/src/position.h
@@ -208,6 +208,8 @@ public:
 #endif
 #ifdef ANTI
   bool is_anti() const;
+  bool is_suicide() const;
+  Value suicide_stalemate(int ply, Value draw) const;
   bool is_anti_win() const;
   bool is_anti_loss() const;
   bool can_capture() const;
@@ -518,6 +520,19 @@ inline bool Position::is_horde_loss() const {
 #ifdef ANTI
 inline bool Position::is_anti() const {
   return var == ANTI_VARIANT;
+}
+
+inline bool Position::is_suicide() const {
+    return subvar == SUICIDE_VARIANT;
+}
+
+inline Value Position::suicide_stalemate(int ply, Value draw) const {
+    int balance = popcount(pieces(sideToMove)) - popcount(pieces(~sideToMove));
+    if (balance > 0)
+        return mated_in(ply);
+    if (balance < 0)
+        return mate_in(ply + 1);
+    return draw;
 }
 
 inline bool Position::is_anti_loss() const {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1319,7 +1319,9 @@ moves_loop: // When in check search starts from here
 #endif
 #ifdef HORDE
         if (pos.is_horde() && pos.is_horde_loss())
-            bestValue = excludedMove ? alpha : mated_in(ss->ply);
+            bestValue = excludedMove ? alpha
+            : pos.is_suicide() ? pos.suicide_stalemate(ss->ply, DrawValue[pos.side_to_move()])
+            : mate_in(ss->ply+1);
         else
 #endif
 #ifdef ANTI

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -83,6 +83,9 @@ const char* WdlSuffixes[SUBVARIANT_NB] = {
 #ifdef ANTI //suicide
     ".stbw",
 #endif
+#ifdef CRAZYHOUSE //loop
+    nullptr,
+#endif
 };
 
 const char* DtzSuffixes[SUBVARIANT_NB] = {
@@ -113,6 +116,9 @@ const char* DtzSuffixes[SUBVARIANT_NB] = {
 #endif
 #ifdef ANTI //suicide
     ".stbz",
+#endif
+#ifdef CRAZYHOUSE //loop
+    nullptr,
 #endif
 };
 
@@ -1296,6 +1302,12 @@ void* init(Entry& e, const Position& pos) {
         {
             { 0xE4, 0xCF, 0xE7, 0x23 },
             { 0x7B, 0xF6, 0x93, 0x15 }
+        },
+#endif
+#ifdef CRAZYHOUSE //loop
+        {
+            { 0xD7, 0x66, 0x0C, 0xA5 },
+            { 0x71, 0xE8, 0x23, 0x5D }
         },
 #endif
     };

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -80,6 +80,9 @@ const char* WdlSuffixes[SUBVARIANT_NB] = {
 #ifdef THREECHECK
     nullptr,
 #endif
+#ifdef ANTI //suicide
+    ".stbw",
+#endif
 };
 
 const char* DtzSuffixes[SUBVARIANT_NB] = {
@@ -107,6 +110,9 @@ const char* DtzSuffixes[SUBVARIANT_NB] = {
 #endif
 #ifdef THREECHECK
     nullptr,
+#endif
+#ifdef ANTI //suicide
+    ".stbz",
 #endif
 };
 
@@ -1284,6 +1290,12 @@ void* init(Entry& e, const Position& pos) {
         {
             { 0xD7, 0x66, 0x0C, 0xA5 },
             { 0x71, 0xE8, 0x23, 0x5D }
+        },
+#endif
+#ifdef ANTI //suicide
+        {
+            { 0xE4, 0xCF, 0xE7, 0x23 },
+            { 0x7B, 0xF6, 0x93, 0x15 }
         },
 #endif
     };

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -54,7 +54,7 @@ int Tablebases::MaxCardinality;
 
 namespace {
 
-const char* WdlSuffixes[VARIANT_NB] = {
+const char* WdlSuffixes[SUBVARIANT_NB] = {
     ".rtbw",
 #ifdef ANTI
     ".gtbw",
@@ -78,11 +78,11 @@ const char* WdlSuffixes[VARIANT_NB] = {
     nullptr,
 #endif
 #ifdef THREECHECK
-    nullptr
+    nullptr,
 #endif
 };
 
-const char* DtzSuffixes[VARIANT_NB] = {
+const char* DtzSuffixes[SUBVARIANT_NB] = {
     ".rtbz",
 #ifdef ANTI
     ".gtbz",
@@ -106,7 +106,7 @@ const char* DtzSuffixes[VARIANT_NB] = {
     nullptr,
 #endif
 #ifdef THREECHECK
-    nullptr
+    nullptr,
 #endif
 };
 
@@ -1233,7 +1233,7 @@ void* init(Entry& e, const Position& pos) {
         b += std::string(popcount(pos.pieces(BLACK, pt)), PieceToChar[pt]);
     }
 
-    const uint8_t TB_MAGIC[VARIANT_NB][2][4] = {
+    const uint8_t TB_MAGIC[SUBVARIANT_NB][2][4] = {
         {
             { 0xD7, 0x66, 0x0C, 0xA5 },
             { 0x71, 0xE8, 0x23, 0x5D }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -214,7 +214,7 @@ void ThreadPool::start_thinking(Position& pos, StateListPtr& states,
       th->tbHits = 0;
       th->rootDepth = DEPTH_ZERO;
       th->rootMoves = rootMoves;
-      th->rootPos.set(pos.fen(), pos.is_chess960(), pos.variant(), &setupStates->back(), th);
+      th->rootPos.set(pos.fen(), pos.is_chess960(), pos.subvariant(), &setupStates->back(), th);
   }
 
   setupStates->back() = tmp; // Restore st->previous, cleared by Position::set()

--- a/src/types.h
+++ b/src/types.h
@@ -110,6 +110,7 @@ const int MAX_MOVES = 256;
 const int MAX_PLY   = 128;
 
 enum Variant {
+  //main variants
   CHESS_VARIANT,
 #ifdef ANTI
   ANTI_VARIANT,
@@ -135,35 +136,41 @@ enum Variant {
 #ifdef THREECHECK
   THREECHECK_VARIANT,
 #endif
-  VARIANT_NB
+  VARIANT_NB,
+  LAST_VARIANT = VARIANT_NB - 1,
+  //subvariants
+  SUBVARIANT_NB,
 };
 
 //static const constexpr char* variants[] doesn't play nicely with uci.h
-static std::vector<std::string> variants = {"chess"
+static std::vector<std::string> variants = {
+//main variants
+"chess",
 #ifdef ANTI
-,"giveaway"
+"giveaway",
 #endif
 #ifdef ATOMIC
-,"atomic"
+"atomic",
 #endif
 #ifdef CRAZYHOUSE
-,"crazyhouse"
+"crazyhouse",
 #endif
 #ifdef HORDE
-,"horde"
+"horde",
 #endif
 #ifdef KOTH
-,"kingofthehill"
+"kingofthehill",
 #endif
 #ifdef RACE
-,"racingkings"
+"racingkings",
 #endif
 #ifdef RELAY
-,"relay"
+"relay",
 #endif
 #ifdef THREECHECK
-,"threecheck"
+"threecheck",
 #endif
+//subvariants
 };
 
 /// A move needs 16 bits to be stored

--- a/src/types.h
+++ b/src/types.h
@@ -139,6 +139,9 @@ enum Variant {
   VARIANT_NB,
   LAST_VARIANT = VARIANT_NB - 1,
   //subvariants
+#ifdef ANTI //suicide
+  SUICIDE_VARIANT,
+#endif
   SUBVARIANT_NB,
 };
 
@@ -171,6 +174,9 @@ static std::vector<std::string> variants = {
 "threecheck",
 #endif
 //subvariants
+#ifdef ANTI //suicide
+"suicide",
+#endif
 };
 
 /// A move needs 16 bits to be stored

--- a/src/types.h
+++ b/src/types.h
@@ -142,6 +142,9 @@ enum Variant {
 #ifdef ANTI //suicide
   SUICIDE_VARIANT,
 #endif
+#ifdef CRAZYHOUSE //loop
+  LOOP_VARIANT,
+#endif
   SUBVARIANT_NB,
 };
 
@@ -176,6 +179,9 @@ static std::vector<std::string> variants = {
 //subvariants
 #ifdef ANTI //suicide
 "suicide",
+#endif
+#ifdef CRAZYHOUSE //loop
+"loop",
 #endif
 };
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -38,31 +38,31 @@ extern void benchmark(const Position& pos, istream& is);
 namespace {
 
   // FEN strings of the initial positions
-  const string StartFENs[VARIANT_NB] = {
-  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  const string StartFENs[SUBVARIANT_NB] = {
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #ifdef ANTI
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef ATOMIC
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef CRAZYHOUSE
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1",
 #endif
 #ifdef HORDE
-  ,"rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1"
+  "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1",
 #endif
 #ifdef KOTH
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef RACE
-  ,"8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
+  "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1",
 #endif
 #ifdef RELAY
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef THREECHECK
-  ,"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1"
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1",
 #endif
   };
 
@@ -330,7 +330,7 @@ Move UCI::to_move(const Position& pos, string& str) {
 
 Variant UCI::variant_from_name(const string& str) {
 
-  for (Variant v = CHESS_VARIANT; v < VARIANT_NB; ++v)
+  for (Variant v = CHESS_VARIANT; v < SUBVARIANT_NB; ++v)
       if (variants[v] == str)
           return v;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -67,6 +67,9 @@ namespace {
 #ifdef ANTI //suicide
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1",
 #endif
+#ifdef CRAZYHOUSE //loop
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1",
+#endif
   };
 
   // A list to keep track of the position states along the setup moves (from the

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -64,6 +64,9 @@ namespace {
 #ifdef THREECHECK
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1",
 #endif
+#ifdef ANTI //suicide
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1",
+#endif
   };
 
   // A list to keep track of the position states along the setup moves (from the


### PR DESCRIPTION
Add support for subvariants and implement suicide and loop chess as such. A revised version of #120.

As a comparison, the implementation of antichess and crazyhouse took about 250 lines each (not including later additions and bugfixes), whereas the subvariants take 30-50 lines. 