### PR TITLE
Double mobility bonus in antichess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1263,6 +1263,11 @@ Value Eval::evaluate(const Position& pos) {
 
   // Evaluate all pieces but king and pawns
   score += evaluate_pieces<DoTrace>(pos, ei, mobility, mobilityArea);
+#ifdef ANTI
+  if (pos.is_anti())
+      score += 2 * (mobility[WHITE] - mobility[BLACK]);
+  else
+#endif
   score += mobility[WHITE] - mobility[BLACK];
 
 #ifdef ANTI


### PR DESCRIPTION
LLR: 2.96 (-2.94,2.94) [0.00,20.00]
Total: 1032 W: 323 L: 263 D: 446