### PR TITLE
Tweak antichess piece values

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -263,12 +263,12 @@ enum Value : int {
   RookValueMg   = 1285,  RookValueEg   = 1371,
   QueenValueMg  = 2513,  QueenValueEg  = 2650,
 #ifdef ANTI
-  PawnValueMgAnti   = -113,  PawnValueEgAnti   = -350,
-  KnightValueMgAnti = -127,  KnightValueEgAnti = -137,
-  BishopValueMgAnti = -256,  BishopValueEgAnti = -99,
-  RookValueMgAnti   = -461,  RookValueEgAnti   = -180,
-  QueenValueMgAnti  = -230,  QueenValueEgAnti  = -327,
-  KingValueMgAnti   = -51,   KingValueEgAnti   =  191,
+  PawnValueMgAnti   = -137,  PawnValueEgAnti   = -360,
+  KnightValueMgAnti = -130,  KnightValueEgAnti = -41,
+  BishopValueMgAnti = -322,  BishopValueEgAnti = -64,
+  RookValueMgAnti   = -496,  RookValueEgAnti   =  62,
+  QueenValueMgAnti  = -187,  QueenValueEgAnti  = -318,
+  KingValueMgAnti   = -20,   KingValueEgAnti   =  130,
 #endif
 #ifdef ATOMIC
   PawnValueMgAtomic   = 332,   PawnValueEgAtomic   = 438,


### PR DESCRIPTION
Especially because of the changes to the second order material bonuses, the optimal piece values have changed.

LLR: 2.98 (-2.94,2.94) [0.00,20.00]
Total: 400 W: 153 L: 105 D: 142