### PR TITLE
Fix detection of final positions in racing kings

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -608,8 +608,16 @@ inline bool Position::is_race_draw() const {
 
 // Loss if king is on the eighth rank (Racing Kings)
 inline bool Position::is_race_loss() const {
-  return rank_of(square<KING>(~sideToMove)) == RANK_8
-        && rank_of(square<KING>(sideToMove)) < (sideToMove == WHITE ? RANK_8 : RANK_7);
+  if (rank_of(square<KING>(~sideToMove)) != RANK_8)
+      return false;
+  if (rank_of(square<KING>(sideToMove)) < (sideToMove == WHITE ? RANK_8 : RANK_7))
+      return true;
+  // Check whether the black king can move to the eighth rank
+  Bitboard b = attacks_from<KING>(square<KING>(sideToMove)) & rank_bb(RANK_8) & ~pieces(sideToMove);
+  while (b)
+      if (!(attackers_to(pop_lsb(&b)) & pieces(~sideToMove)))
+          return false;
+  return true;
 }
 #endif
 


### PR DESCRIPTION
When the white king is on the eighth rank and the black king can not advance, the game is already over before black's move.

An example is the position `1R6/k1Kn4/8/5Q2/8/8/4N3/3nN3 w - - 0 1` as [reported in the lichess forum](https://en.lichess.org/forum/lichess-feedback/bug----analysis-bugged-for-racing-kings).