### PR TITLE
Tweak unsupported pawn penalty for horde

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -102,7 +102,7 @@ namespace {
     S( 17,   8),
 #endif
 #ifdef HORDE
-    S( 17,   8),
+    S( 47,  50),
 #endif
 #ifdef KOTH
     S( 17,   8),


### PR DESCRIPTION
LLR: 3.03 (-2.94,2.94) [0.00,20.00]
Total: 676 W: 367 L: 296 D: 13