### PR TITLE
Tweak evaluation of pawns for horde chess

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -44,7 +44,7 @@ namespace {
     { S(45, 40), S(30, 27) },
 #endif
 #ifdef HORDE
-    { S(45, 40), S(30, 27) },
+    { S(60, 44), S(18, 38) },
 #endif
 #ifdef KOTH
     { S(45, 40), S(30, 27) },
@@ -73,7 +73,7 @@ namespace {
     { S(56, 33), S(41, 19) },
 #endif
 #ifdef HORDE
-    { S(56, 33), S(41, 19) },
+    { S(48, 26), S(80, 15) },
 #endif
 #ifdef KOTH
     { S(56, 33), S(41, 19) },
@@ -134,7 +134,7 @@ namespace {
     S(18, 38),
 #endif
 #ifdef HORDE
-    S(18, 38),
+    S(-26, 78),
 #endif
 #ifdef KOTH
     S(18, 38),

--- a/src/types.h
+++ b/src/types.h
@@ -285,7 +285,7 @@ enum Value : int {
   QueenValueMgHouse  = 936,   QueenValueEgHouse  = 1222,
 #endif
 #ifdef HORDE
-  PawnValueMgHorde   = 406,   PawnValueEgHorde   = 427,
+  PawnValueMgHorde   = 370,   PawnValueEgHorde   = 427,
   KnightValueMgHorde = 708,   KnightValueEgHorde = 851,
   BishopValueMgHorde = 736,   BishopValueEgHorde = 859,
   RookValueMgHorde   = 1341,  RookValueEgHorde   = 1175,


### PR DESCRIPTION
LLR: 2.97 (-2.94,2.94) [0.00,20.00]
Total: 254 W: 154 L: 96 D: 4