### PR TITLE
Tweak crazyhouse king safety evaluation

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -579,7 +579,7 @@ namespace {
                     + 134 * (popcount(b) + !!ei.pinnedPieces[Us])
                     - 717 * (!(pos.count<QUEEN>(Them)
 #ifdef CRAZYHOUSE
-                               || pos.is_house() && pos.count_in_hand(Them, QUEEN))
+                               || pos.is_house())
 #endif
                             )
                     -   7 * mg_value(score) / 5 - 5;


### PR DESCRIPTION
To have a queen is not essential for a mating attack in crazyhouse.

STC 10+0.1
LLR: 2.97 (-2.94,2.94) [0.00,20.00]
Total: 606 W: 311 L: 246 D: 49

LTC 30+0.3
LLR: 2.98 (-2.94,2.94) [0.00,20.00]
Total: 470 W: 256 L: 193 D: 21