### PR TITLE
Fix wrong placement of bracket

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -599,9 +599,9 @@ namespace {
                     + 134 * (popcount(b) + !!ei.pinnedPieces[Us])
                     - 717 * (!(pos.count<QUEEN>(Them)
 #ifdef CRAZYHOUSE
-                               || pos.is_house())
+                               || pos.is_house()
 #endif
-                            )
+                            ))
                     -   7 * mg_value(score) / 5 - 5;
         Bitboard h = 0;
 


### PR DESCRIPTION
Error occured if compiled without crazyhouse.

I have started to compare bench numbers when compiling with all and only one variant, respectively, and encountered this error.