### PR TITLE
Support syzygy giveaway tablebases (closes #114)

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -90,31 +90,31 @@ namespace {
 
 Endgames::Endgames() {
 
-  add<KPK>("KPK");
-  add<KNNK>("KNNK");
-  add<KBNK>("KBNK");
-  add<KRKP>("KRKP");
-  add<KRKB>("KRKB");
-  add<KRKN>("KRKN");
-  add<KQKP>("KQKP");
-  add<KQKR>("KQKR");
+  add<KPK>("KPvK");
+  add<KNNK>("KNNvK");
+  add<KBNK>("KBNvK");
+  add<KRKP>("KRvKP");
+  add<KRKB>("KRvKB");
+  add<KRKN>("KRvKN");
+  add<KQKP>("KQvKP");
+  add<KQKR>("KQvKR");
 
-  add<KNPK>("KNPK");
-  add<KNPKB>("KNPKB");
-  add<KRPKR>("KRPKR");
-  add<KRPKB>("KRPKB");
-  add<KBPKB>("KBPKB");
-  add<KBPKN>("KBPKN");
-  add<KBPPKB>("KBPPKB");
-  add<KRPPKRP>("KRPPKRP");
+  add<KNPK>("KNPvK");
+  add<KNPKB>("KNPvKB");
+  add<KRPKR>("KRPvKR");
+  add<KRPKB>("KRPvKB");
+  add<KBPKB>("KBPvKB");
+  add<KBPKN>("KBPvKN");
+  add<KBPPKB>("KBPPvKB");
+  add<KRPPKRP>("KRPPvKRP");
 }
 
 
 template<EndgameType E, typename T>
 void Endgames::add(const string& code) {
   StateInfo st;
-  map<T>()[Position().set(code, WHITE, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(WHITE));
-  map<T>()[Position().set(code, BLACK, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(BLACK));
+  map<T>()[Position().set(code, WHITE, CHESS_VARIANT, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(WHITE));
+  map<T>()[Position().set(code, BLACK, CHESS_VARIANT, &st).material_key()] = std::unique_ptr<EndgameBase<T>>(new Endgame<E>(BLACK));
 }
 
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -602,24 +602,23 @@ void Position::set_state(StateInfo* si) const {
 
 
 /// Position::set() is an overload to initialize the position object with
-/// the given endgame code string like "KBPKN". It is manily an helper to
+/// the given endgame code string like "KBPvKN". It is mainly an helper to
 /// get the material key out of an endgame code. Position is not playable,
 /// indeed is even not guaranteed to be legal.
 
-Position& Position::set(const string& code, Color c, StateInfo* si) {
+Position& Position::set(const string& code, Color c, Variant v, StateInfo* si) {
 
   assert(code.length() > 0 && code.length() < 8);
-  assert(code[0] == 'K');
 
-  string sides[] = { code.substr(code.find('K', 1)),      // Weak
-                     code.substr(0, code.find('K', 1)) }; // Strong
+  string sides[] = { code.substr(code.find('v') + 1),  // Weak
+                     code.substr(0, code.find('v')) }; // Strong
 
   std::transform(sides[c].begin(), sides[c].end(), sides[c].begin(), tolower);
 
   string fenStr =  sides[0] + char(8 - sides[0].length() + '0') + "/8/8/8/8/8/8/"
                  + sides[1] + char(8 - sides[1].length() + '0') + " w - - 0 10";
 
-  return set(fenStr, false, CHESS_VARIANT, si, nullptr);
+  return set(fenStr, false, v, si, nullptr);
 }
 
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -608,7 +608,7 @@ void Position::set_state(StateInfo* si) const {
 
 Position& Position::set(const string& code, Color c, Variant v, StateInfo* si) {
 
-  assert(code.length() > 0 && code.length() < 8);
+  assert(code.length() > 0 && code.length() < 9);
 
   string sides[] = { code.substr(code.find('v') + 1),  // Weak
                      code.substr(0, code.find('v')) }; // Strong

--- a/src/position.h
+++ b/src/position.h
@@ -88,7 +88,7 @@ public:
 
   // FEN string input/output
   Position& set(const std::string& fenStr, bool isChess960, Variant v, StateInfo* si, Thread* th);
-  Position& set(const std::string& code, Color c, StateInfo* si);
+  Position& set(const std::string& code, Color c, Variant v, StateInfo* si);
   const std::string fen() const;
 
   // Position representation

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1944,6 +1944,9 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
         return dtz_before_zeroing(wdl);
 
 #ifdef ANTI
+    if (pos.pieces(pos.side_to_move()) == pos.pieces(pos.side_to_move(), PAWN))
+        return dtz_before_zeroing(wdl);
+
     if (*result == THREAT && wdl > WDLDraw)
         return wdl == WDLWin ? 2 : 102;
 #endif

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1383,8 +1383,14 @@ void do_init(Entry& e, T& p, uint8_t* data) {
     data += (uintptr_t)data & 1; // Word alignment
 
     for (File f = FILE_A; f <= MaxFile; ++f)
-        for (int i = 0; i < Sides; i++)
+        for (int i = 0; i < Sides; i++) {
             data = set_sizes(item(p, i, f).precomp, data);
+
+#ifdef ANTI
+            if (!IsWDL && e.variant == ANTI_VARIANT && item(p, i, f).precomp->flags & TBFlag::SingleValue)
+                item(p, i, f).precomp->minSymLen = 1;
+#endif
+        }
 
     if (!IsWDL)
         data = set_dtz_map(e, p, data, MaxFile);

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1129,7 +1129,7 @@ T do_probe_table(const Position& pos,  Entry* entry, WDLScore wdl, ProbeState* r
         idx = MultIdx[d->groupLen[0] - 1][Triangle[squares[0]]];
 
         for (int i = 1; i < d->groupLen[0]; ++i)
-            idx += Binomial[i - 1][MultTwist[squares[i]]];
+            idx += Binomial[i][MultTwist[squares[i]]];
     }
 
 encode_remaining:
@@ -1791,7 +1791,7 @@ void Tablebases::init(const std::string& paths, Variant variant) {
         int s = 0;
         for (int j = 0; j < 10; j++) {
             MultIdx[i][j] = s;
-            s += (i == 0) ? 1 : Binomial[i - 1][MultTwist[InvTriangle[j]]];
+            s += (i == 0) ? 1 : Binomial[i][MultTwist[InvTriangle[j]]];
         }
         MultFactor[i] = s;
     }

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1569,6 +1569,8 @@ WDLScore sprobe_captures(Position &pos, WDLScore alpha, WDLScore beta, ProbeStat
     auto moveList = MoveList<CAPTURES>(pos);
     StateInfo st;
 
+    *result = OK;
+
     for (const Move& move : moveList) {
         pos.do_move(move, st);
         WDLScore v = -sprobe_ab(pos, -beta, -alpha, result);
@@ -1630,7 +1632,9 @@ WDLScore sprobe_ab(Position &pos, WDLScore alpha, WDLScore beta, ProbeState* res
         }
     }
 
+    *result = OK;
     v = probe_table<WDLEntry>(pos, result);
+
     if (*result == FAIL)
         return WDLDraw;
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1105,8 +1105,31 @@ T do_probe_table(const Position& pos,  Entry* entry, WDLScore wdl, ProbeState* r
 
         idx = MapPP[Triangle[squares[0]]][squares[1]];
     } else {
-        // TODO: Decode like man tables for giveaway/suicide.
-        std::cout << "NOT IMPLEMENTED (minLikeMan > 2) !!!!!!!!!" << std::endl;
+        for (int i = 1; i < d->groupLen[0]; ++i)
+            if (Triangle[squares[0]] > Triangle[squares[i]])
+                std::swap(squares[0], squares[i]);
+
+        if (file_of(squares[0]) > FILE_D)
+            for (int i = 0; i < size; ++i)
+                squares[i] ^= 7;
+
+        if (rank_of(squares[0]) > RANK_4)
+            for (int i = 0; i < size; ++i)
+                squares[i] ^= 070;
+
+        if (off_A1H8(squares[0]) > 0)
+            for (int i = 0; i < size; ++i)
+                squares[i] = flipdiag(squares[i]);
+
+        for (int i = 1; i < d->groupLen[0]; i++)
+            for (int j = i + 1; j < d->groupLen[0]; j++)
+                if (MultTwist[squares[i]] > MultTwist[squares[j]])
+                    std::swap(squares[i], squares[j]);
+
+        idx = MultIdx[d->groupLen[0] - 1][Triangle[squares[0]]];
+
+        for (int i = 1; i < d->groupLen[0]; ++i)
+            idx += Binomial[i - 1][MultTwist[squares[i]]];
     }
 
 encode_remaining:

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1592,7 +1592,7 @@ WDLScore sprobe_captures(Position &pos, WDLScore alpha, WDLScore beta, ProbeStat
     return alpha;
 }
 
-template<bool Threats = false>
+template<bool Threats>
 WDLScore sprobe_ab(Position &pos, WDLScore alpha, WDLScore beta, ProbeState* result) {
 
     WDLScore v;

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1937,6 +1937,11 @@ int Tablebases::probe_dtz(Position& pos, ProbeState* result) {
     if (*result == ZEROING_BEST_MOVE)
         return dtz_before_zeroing(wdl);
 
+#ifdef ANTI
+    if (*result == THREAT && wdl > WDLDraw)
+        return wdl == WDLWin ? 2 : 102;
+#endif
+
     int dtz = probe_table<DTZEntry>(pos, result, wdl);
 
     if (*result == FAIL)

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -914,9 +914,17 @@ T do_probe_table(const Position& pos,  Entry* entry, WDLScore wdl, ProbeState* r
                  +  rank_of(squares[0])         * 7 * 6
                  + (rank_of(squares[1]) - adjust1)  * 6
                  + (rank_of(squares[2]) - adjust2);
-    } else {
+    } else if (entry->numUniquePieces == 2) {
+
+        bool connectedKings = false;
 #ifdef ATOMIC
-        if (entry->variant == ATOMIC_VARIANT) {
+        connectedKings = connectedKings || entry->variant == ATOMIC_VARIANT;
+#endif
+#ifdef ANTI
+        connectedKings = connectedKings || entry->variant == ANTI_VARIANT;
+#endif
+
+        if (connectedKings) {
             int adjust = squares[1] > squares[0];
 
             if (off_A1H8(squares[0]))

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -265,6 +265,7 @@ int MapKK[10][SQUARE_NB]; // [MapA1D1D4][SQUARE_NB]
 // Comparison function to sort leading pawns in ascending MapPawns[] order
 bool pawns_comp(Square i, Square j) { return MapPawns[i] < MapPawns[j]; }
 int off_A1H8(Square sq) { return int(rank_of(sq)) - file_of(sq); }
+Square flipdiag(Square square) { return Square(((square >> 3) | (square << 3)) & 63); }
 
 const Value WDL_to_value[] = {
    -VALUE_MATE + MAX_PLY + 1,
@@ -972,7 +973,7 @@ T do_probe_table(const Position& pos,  Entry* entry, WDLScore wdl, ProbeState* r
 
         if (off_A1H8(squares[i]) > 0) // A1-H8 diagonal flip: SQ_A3 -> SQ_C3
             for (int j = i; j < size; ++j)
-                squares[j] = Square(((squares[j] >> 3) | (squares[j] << 3)) & 63);
+                squares[j] = flipdiag(squares[j]);
         break;
     }
 

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -41,7 +41,8 @@ enum ProbeState {
     FAIL              =  0, // Probe failed (missing file table)
     OK                =  1, // Probe succesful
     CHANGE_STM        = -1, // DTZ should check the other side
-    ZEROING_BEST_MOVE =  2  // Best move zeroes DTZ (capture or pawn move)
+    ZEROING_BEST_MOVE =  2, // Best move zeroes DTZ (capture or pawn move)
+    THREAT            =  3  // Threatening to force capture in giveaway
 };
 
 extern int MaxCardinality;
@@ -69,7 +70,8 @@ inline std::ostream& operator<<(std::ostream& os, const ProbeState v) {
     os << (v == FAIL              ? "Failed" :
            v == OK                ? "Success" :
            v == CHANGE_STM        ? "Probed opponent side" :
-           v == ZEROING_BEST_MOVE ? "Best move zeroes DTZ" : "None");
+           v == ZEROING_BEST_MOVE ? "Best move zeroes DTZ" :
+           v == THREAT            ? "Threat" : "None");
 
     return os;
 }


### PR DESCRIPTION
This batch of commits adds support for giveaway tablebases (#114). It's non trivial but pretty self contained.

**The only change outside of the syzygy folder involves endgame codes.** An endgame in the old style like `KKKB` would not be unique in antichess, because kings can't be used as the seperator. Instead use `KKKvB`.

**Future work:** This will require one more follow up commit to enable 5 piece and 6 piece tables once I tested them. Aditionally pawnless tables are indentical in giveaway and suicide, so code could be added to allow sharing.