### PR TITLE
Tweak futility pruning in qsearch for crazyhouse

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1532,6 +1532,11 @@ moves_loop: // When in check search starts from here
       {
           assert(type_of(move) != ENPASSANT); // Due to !pos.advanced_pawn_push
 
+#ifdef CRAZYHOUSE
+          if (pos.is_house())
+              futilityValue = futilityBase + 2 * PieceValue[pos.variant()][EG][pos.piece_on(to_sq(move))];
+          else
+#endif
           futilityValue = futilityBase + PieceValue[pos.variant()][EG][pos.piece_on(to_sq(move))];
 
           if (futilityValue <= alpha)


### PR DESCRIPTION
In crazyhouse, a capture changes the evaluation by twice the piece value of the captured piece. Account for this in futility pruning.

STC 10+0.1
LLR: 3.05 (-2.94,2.94) [0.00,20.00]
Total: 614 W: 332 L: 263 D: 19

LTC 30+0.3
LLR: 3.05 (-2.94,2.94) [0.00,20.00]
Total: 1570 W: 800 L: 704 D: 66