### PR TITLE
Fix array size of DtzSuffixes

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -82,7 +82,7 @@ const char* WdlSuffixes[SUBVARIANT_NB] = {
 #endif
 };
 
-const char* PawnlessWdlSuffixes[VARIANT_NB] = {
+const char* PawnlessWdlSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #ifdef ANTI
     ".stbw",


### PR DESCRIPTION
This should fix the compiler error mentioned in [#110](https://github.com/ddugovic/Stockfish/issues/110#issuecomment-269006906).