### PR TITLE
Add compile-time assertions for subvariants

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -102,6 +102,15 @@ const bool Is64Bit = false;
 typedef uint64_t Key;
 typedef uint64_t Bitboard;
 
+// Check whether main variants of subvariants are enabled
+#if defined(LOOP) && !defined(CRAZYHOUSE)
+#error Crazyhouse is required for subvariant loop chess.
+#endif
+
+#if defined(SUICIDE) && !defined(ANTI)
+#error Giveaway (ANTI) is required for subvariant suicide chess.
+#endif
+
 #ifdef CRAZYHOUSE
 const int MAX_MOVES = 512;
 #else


### PR DESCRIPTION
My attempt to realize the suggestion from https://github.com/ddugovic/Stockfish/commit/e5e45724699369bfb457b92149f95ee18b7b86b8#commitcomment-20288064.

Compiling with suicide but without giveaway now gives a compiler error message. Same for loop chess and crazyhouse.