### PR TITLE
Tweak futility pruning for horde chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -880,7 +880,11 @@ namespace {
         &&  depth < 7 * ONE_PLY
         &&  eval - futility_margin(pos.variant(), depth) >= beta
         &&  eval < VALUE_KNOWN_WIN  // Do not return unproven wins
+#ifdef HORDE
+        &&  (pos.non_pawn_material(pos.side_to_move()) || pos.is_horde()))
+#else
         &&  pos.non_pawn_material(pos.side_to_move()))
+#endif
         return eval;
 
     // Step 8. Null move search with verification search (is omitted in PV nodes)


### PR DESCRIPTION
The horde does not have non-pawn material, so remove this requirement from futility pruning for horde chess.

STC 10+0.1
LLR: 3.00 (-2.94,2.94) [0.00,20.00]
Total: 1416 W: 742 L: 650 D: 24

LTC 30+0.3
LLR: 3.03 (-2.94,2.94) [0.00,20.00]
Total: 3688 W: 1897 L: 1739 D: 52