### PR TITLE
Use SEE for qsearch futility pruning margin in atomic chess

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -150,6 +150,9 @@ public:
   void undo_null_move();
 
   // Static Exchange Evaluation
+#ifdef ATOMIC
+  Value atomic_see(Move m) const;
+#endif
   bool see_ge(Move m, Value value) const;
 
   // Accessing hash keys

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1535,6 +1535,11 @@ moves_loop: // When in check search starts from here
       {
           assert(type_of(move) != ENPASSANT); // Due to !pos.advanced_pawn_push
 
+#ifdef ATOMIC
+          if (pos.is_atomic())
+              futilityValue = futilityBase + pos.atomic_see(move);
+          else
+#endif
 #ifdef CRAZYHOUSE
           if (pos.is_house())
               futilityValue = futilityBase + 2 * PieceValue[pos.variant()][EG][pos.piece_on(to_sq(move))];


### PR DESCRIPTION
STC 10+0.1
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 3110 W: 1068 L: 953 D: 1089

LTC 30+0.3
LLR: 3.01 (-2.94,2.94) [0.00,10.00]
Total: 1142 W: 393 L: 304 D: 445

I changed the bounds, because many patches did not pass tests despite a positive score.