### PR TITLE
Implement losers chess

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -252,7 +252,7 @@ ifneq ($(comp),mingw)
 endif
 
 ### 3.2.1 Debugging
-CXXFLAGS += -DANTI -DATOMIC -DCRAZYHOUSE -DHORDE -DKOTH -DLOOP -DRACE -DSUICIDE -DTHREECHECK
+CXXFLAGS += -DANTI -DATOMIC -DCRAZYHOUSE -DHORDE -DKOTH -DLOOP -DLOSERS -DRACE -DSUICIDE -DTHREECHECK
 ifneq (,$(filter -DLOOP,$(CXXFLAGS)))
 ifeq (,$(filter -DCRAZYHOUSE,$(CXXFLAGS)))
 $(error Crazyhouse (-DCRAZYHOUSE) is required for subvariant loop chess)

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -111,6 +111,11 @@ const vector<string> Defaults[VARIANT_NB] = {
     "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
   },
 #endif
+#ifdef LOSERS
+  {
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  },
+#endif
 #ifdef RACE
   {
     "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1227,6 +1227,16 @@ Value Eval::evaluate(const Position& pos) {
             return -VALUE_MATE;
     }
 #endif
+#ifdef LOSERS
+    // Possibly redundant static evaluator
+    if (pos.is_losers())
+    {
+        if (pos.is_losers_win())
+            return VALUE_MATE;
+        if (pos.is_losers_loss())
+            return -VALUE_MATE;
+    }
+#endif
 #ifdef RACE
     // Possibly redundant static evaluator
     if (pos.is_race())
@@ -1285,6 +1295,9 @@ Value Eval::evaluate(const Position& pos) {
   // configuration, call it and return.
 #ifdef KOTH
   if (pos.is_koth()) {} else
+#endif
+#ifdef LOSERS
+  if (pos.is_losers()) {} else
 #endif
 #ifdef RACE
   if (pos.is_race()) {} else

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -208,6 +208,12 @@ namespace {
       { V(7), V(14), V(38), V(73), V(166), V(252) }
     },
 #endif
+#ifdef LOSERS
+    {
+      { V(5), V( 5), V(31), V(73), V(166), V(252) },
+      { V(7), V(14), V(38), V(73), V(166), V(252) }
+    },
+#endif
 #ifdef RACE
     {
       { V(5), V( 5), V(31), V(73), V(166), V(252) },
@@ -299,6 +305,9 @@ namespace {
     S( 7,  0),
 #endif
 #ifdef KOTH
+    S( 7,  0),
+#endif
+#ifdef LOSERS
     S( 7,  0),
 #endif
 #ifdef RACE
@@ -548,6 +557,9 @@ namespace {
     2 * int(BishopValueMg),
 #endif
 #ifdef KOTH
+    2 * int(BishopValueMg),
+#endif
+#ifdef LOSERS
     2 * int(BishopValueMg),
 #endif
 #ifdef RACE

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -46,6 +46,9 @@ const Value Tempo[VARIANT_NB] = { // Must be visible to search
 #ifdef KOTH
   Value(20),
 #endif
+#ifdef LOSERS
+  Value(20),
+#endif
 #ifdef RACE
   Value(100),
 #endif

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -211,6 +211,9 @@ Entry* probe(const Position& pos) {
 #ifdef KOTH
           if (pos.is_koth()) {} else
 #endif
+#ifdef LOSERS
+          if (pos.is_losers()) {} else
+#endif
 #ifdef RACE
           if (pos.is_race()) {} else
 #endif
@@ -237,6 +240,9 @@ Entry* probe(const Position& pos) {
       {
 #ifdef KOTH
           if (pos.is_koth()) {} else
+#endif
+#ifdef LOSERS
+          if (pos.is_losers()) {} else
 #endif
 #ifdef RACE
           if (pos.is_race()) {} else

--- a/src/material.h
+++ b/src/material.h
@@ -53,6 +53,9 @@ struct Entry {
 #ifdef KOTH
     if (pos.is_koth()) return SCALE_FACTOR_NORMAL;
 #endif
+#ifdef LOSERS
+    if (pos.is_losers()) return SCALE_FACTOR_NORMAL;
+#endif
 #ifdef RACE
     if (pos.is_race()) return SCALE_FACTOR_NORMAL;
 #endif

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -180,6 +180,13 @@ namespace {
             b2 = shift<Up>(b1 & (TRank2BB | TRank3BB)) & emptySquares;
 #endif
 
+#ifdef LOSERS
+        if (pos.is_losers())
+        {
+            b1 &= target;
+            b2 &= target;
+        }
+#endif
         if (Type == EVASIONS) // Consider only blocking squares
         {
             b1 &= target;
@@ -243,6 +250,10 @@ namespace {
         }
 #ifdef ANTI
         if (pos.is_anti())
+            emptySquares &= target;
+#endif
+#ifdef LOSERS
+        if (pos.is_losers())
             emptySquares &= target;
 #endif
 
@@ -427,6 +438,10 @@ namespace {
             *moveList++ = make_move(ksq, pop_lsb(&b));
     }
 
+#ifdef LOSERS
+    if (pos.is_losers() && pos.can_capture_losers())
+        return moveList;
+#endif
     if (Type != CAPTURES && Type != EVASIONS && pos.can_castle(Us))
     {
         if (pos.is_chess960())
@@ -474,6 +489,10 @@ ExtMove* generate(const Position& pos, ExtMove* moveList) {
 #ifdef ATOMIC
   if (pos.is_atomic() && Type == CAPTURES)
       target &= ~pos.attacks_from<KING>(pos.square<KING>(us));
+#endif
+#ifdef LOSERS
+  if (pos.is_losers() && pos.can_capture_losers())
+      target &= pos.pieces(~us);
 #endif
 
   return us == WHITE ? generate_all<WHITE, Type>(pos, moveList, target)
@@ -576,6 +595,10 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
   else
 #endif
   b = pos.attacks_from<KING>(ksq) & ~pos.pieces(us) & ~sliderAttacks;
+#ifdef LOSERS
+  if (pos.is_losers() && pos.can_capture_losers())
+      b &= pos.pieces(~us);
+#endif
   while (b)
       *moveList++ = make_move(ksq, pop_lsb(&b));
 
@@ -591,6 +614,10 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
   else
 #endif
   target = between_bb(checksq, ksq) | checksq;
+#ifdef LOSERS
+  if (pos.is_losers() && pos.can_capture_losers())
+      target &= pos.pieces(~us);
+#endif
 
   return us == WHITE ? generate_all<WHITE, EVASIONS>(pos, moveList, target)
                      : generate_all<BLACK, EVASIONS>(pos, moveList, target);
@@ -611,6 +638,10 @@ ExtMove* generate<LEGAL>(const Position& pos, ExtMove* moveList) {
 #endif
 #ifdef KOTH
   if (pos.is_koth() && (pos.is_koth_win() || pos.is_koth_loss()))
+      return moveList;
+#endif
+#ifdef LOSERS
+  if (pos.is_losers() && (pos.is_losers_win() || pos.is_losers_loss()))
       return moveList;
 #endif
 #ifdef RACE

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -49,6 +49,9 @@ namespace {
 #ifdef KOTH
     { S(45, 40), S(30, 27) },
 #endif
+#ifdef LOSERS
+    { S(50, 80), S(54, 69) },
+#endif
 #ifdef RACE
     {},
 #endif
@@ -78,6 +81,9 @@ namespace {
 #ifdef KOTH
     { S(56, 33), S(41, 19) },
 #endif
+#ifdef LOSERS
+    { S(64, 25), S(26, 50) },
+#endif
 #ifdef RACE
     {},
 #endif
@@ -106,6 +112,9 @@ namespace {
 #endif
 #ifdef KOTH
     S( 17,   8),
+#endif
+#ifdef LOSERS
+    S(-45, -48),
 #endif
 #ifdef RACE
     S(  0,   0),
@@ -138,6 +147,9 @@ namespace {
 #endif
 #ifdef KOTH
     S(18, 38),
+#endif
+#ifdef LOSERS
+    S( 4, 51),
 #endif
 #ifdef RACE
     S( 0,  0),
@@ -197,6 +209,14 @@ namespace {
   },
 #endif
 #ifdef KOTH
+  {
+    { V(100), V(20), V(10), V(46), V(82), V( 86), V( 98) },
+    { V(116), V( 4), V(28), V(87), V(94), V(108), V(104) },
+    { V(109), V( 1), V(59), V(87), V(62), V( 91), V(116) },
+    { V( 75), V(12), V(43), V(59), V(90), V( 84), V(112) }
+  },
+#endif
+#ifdef LOSERS
   {
     { V(100), V(20), V(10), V(46), V(82), V( 86), V( 98) },
     { V(116), V( 4), V(28), V(87), V(94), V(108), V(104) },

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -924,6 +924,11 @@ bool Position::pseudo_legal(const Move m) const {
   if (is_koth() && (is_koth_win() || is_koth_loss()))
       return false;
 #endif
+#ifdef LOSERS
+  // If the game is already won or lost, further moves are illegal
+  if (is_losers() && (is_losers_win() || is_losers_loss()))
+      return false;
+#endif
 #ifdef RACE
   // If the game is already won or lost, further moves are illegal
   if (is_race() && (is_race_draw() || is_race_win() || is_race_loss()))
@@ -975,6 +980,10 @@ bool Position::pseudo_legal(const Move m) const {
 #endif
 #ifdef ANTI
   if (is_anti() && !capture(m) && can_capture())
+      return false;
+#endif
+#ifdef LOSERS
+  if (is_losers() && !capture(m) && can_capture_losers())
       return false;
 #endif
 

--- a/src/position.h
+++ b/src/position.h
@@ -573,25 +573,34 @@ inline bool Position::is_losers_win() const {
   return count<ALL_PIECES>(sideToMove) == 1;
 }
 
+// Position::can_capture_losers checks whether we have a legal capture
+// in a losers chess position.
+
 inline bool Position::can_capture_losers() const {
+  // En passent captures
   if (ep_square() != SQ_NONE && !checkers())
       if (attackers_to(ep_square()) & pieces(sideToMove, PAWN) & ~pinned_pieces(sideToMove))
           return true;
   Bitboard b = pieces(sideToMove);
+  // Double check forces the king to move
   if (more_than_one(checkers()))
       b &= pieces(sideToMove, KING);
+  // Loop over our pieces to find possible captures
   while (b)
   {
       Square s = pop_lsb(&b);
       Bitboard attacked = attacks_from(piece_on(s), s) & pieces(~sideToMove);
+      // A pinned piece may only take the pinner
       if (pinned_pieces(sideToMove) & s)
           attacked &= LineBB[s][square<KING>(sideToMove)];
+      // The king can only capture undefended pieces
       if (type_of(piece_on(s)) == KING)
       {
           while (attacked)
               if (!(attackers_to(pop_lsb(&attacked)) & pieces(~sideToMove)))
                   return true;
       }
+      // If we are in check, any legal capture has to remove the checking piece
       else if (checkers() ? attacked & checkers() : attacked)
           return true;
   }

--- a/src/psqt.cpp
+++ b/src/psqt.cpp
@@ -39,6 +39,9 @@ Value TempoValue[VARIANT_NB][PHASE_NB] = {
 #ifdef KOTH
   { TempoMg, TempoEg },
 #endif
+#ifdef LOSERS
+  { TempoMgLosers, TempoEgLosers },
+#endif
 #ifdef RACE
   { TempoMgRace, TempoEgRace },
 #endif
@@ -82,6 +85,12 @@ Value PieceValue[VARIANT_NB][PHASE_NB][PIECE_NB] = {
 {
   { VALUE_ZERO, PawnValueMgHill, KnightValueMgHill, BishopValueMgHill, RookValueMgHill, QueenValueMgHill },
   { VALUE_ZERO, PawnValueEgHill, KnightValueEgHill, BishopValueEgHill, RookValueEgHill, QueenValueEgHill },
+},
+#endif
+#ifdef LOSERS
+{
+  { VALUE_ZERO, PawnValueMgLosers, KnightValueMgLosers, BishopValueMgLosers, RookValueMgLosers, QueenValueMgLosers },
+  { VALUE_ZERO, PawnValueEgLosers, KnightValueEgLosers, BishopValueEgLosers, RookValueEgLosers, QueenValueEgLosers },
 },
 #endif
 #ifdef RACE
@@ -492,6 +501,70 @@ const Score Bonus[VARIANT_NB][PIECE_TYPE_NB][RANK_NB][int(FILE_NB) / 2] = {
       { S(177,107), S(189,230), S(141,172), S(211,251) },
       { S( 26, 36), S(164,145), S(102,139), S(-42,133) },
       { S(147,  2), S(186,  7), S( 49, 79), S( 48, 50) }
+    }
+  },
+#endif
+#ifdef LOSERS
+  {
+    { },
+    { // Pawn
+      { S(  0, 0), S(  0, 0), S(  0, 0), S( 0, 0) },
+      { S(-11, 7), S(  6,-4), S(  7, 8), S( 3,-2) },
+      { S(-18,-4), S( -2,-5), S( 19, 5), S(24, 4) },
+      { S(-17, 3), S( -9, 3), S( 20,-8), S(35,-3) },
+      { S(- 6, 8), S(  5, 9), S(  3, 7), S(21,-6) },
+      { S(- 6, 8), S(- 8,-5), S( -6, 2), S(-2, 4) },
+      { S( -4, 3), S( 20,-9), S( -8, 1), S(-4,18) }
+    },
+    { // Knight
+      { S(-143, -97), S(-96,-82), S(-80,-46), S(-73,-14) },
+      { S( -83, -69), S(-43,-55), S(-21,-17), S(-10,  9) },
+      { S( -71, -50), S(-22,-39), S(  0, -8), S(  9, 28) },
+      { S( -25, -41), S( 18,-25), S( 43,  7), S( 47, 38) },
+      { S( -26, -46), S( 16,-25), S( 38,  2), S( 50, 41) },
+      { S( -11, -55), S( 37,-38), S( 56, -8), S( 71, 27) },
+      { S( -62, -64), S(-17,-50), S(  5,-24), S( 14, 13) },
+      { S(-195,-110), S(-66,-90), S(-42,-50), S(-29,-13) }
+    },
+    { // Bishop
+      { S(-54,-68), S(-23,-40), S(-35,-46), S(-44,-28) },
+      { S(-30,-43), S( 10,-17), S(  2,-23), S( -9, -5) },
+      { S(-19,-32), S( 17, -9), S( 11,-13), S(  1,  8) },
+      { S(-21,-36), S( 18,-13), S( 11,-15), S(  0,  7) },
+      { S(-21,-36), S( 14,-14), S(  6,-17), S( -1,  3) },
+      { S(-27,-35), S(  6,-13), S(  2,-10), S( -8,  1) },
+      { S(-33,-44), S(  7,-21), S( -4,-22), S(-12, -4) },
+      { S(-45,-65), S(-21,-42), S(-29,-46), S(-39,-27) }
+    },
+    { // Rook
+      { S(-25, 0), S(-16, 0), S(-16, 0), S(-9, 0) },
+      { S(-21, 0), S( -8, 0), S( -3, 0), S( 0, 0) },
+      { S(-21, 0), S( -9, 0), S( -4, 0), S( 2, 0) },
+      { S(-22, 0), S( -6, 0), S( -1, 0), S( 2, 0) },
+      { S(-22, 0), S( -7, 0), S(  0, 0), S( 1, 0) },
+      { S(-21, 0), S( -7, 0), S(  0, 0), S( 2, 0) },
+      { S(-12, 0), S(  4, 0), S(  8, 0), S(12, 0) },
+      { S(-23, 0), S(-15, 0), S(-11, 0), S(-5, 0) }
+    },
+    { // Queen
+      { S( 0,-70), S(-3,-57), S(-4,-41), S(-1,-29) },
+      { S(-4,-58), S( 6,-30), S( 9,-21), S( 8, -4) },
+      { S(-2,-39), S( 6,-17), S( 9, -7), S( 9,  5) },
+      { S(-1,-29), S( 8, -5), S(10,  9), S( 7, 17) },
+      { S(-3,-27), S( 9, -5), S( 8, 10), S( 7, 23) },
+      { S(-2,-40), S( 6,-16), S( 8,-11), S(10,  3) },
+      { S(-2,-54), S( 7,-30), S( 7,-21), S( 6, -7) },
+      { S(-1,-75), S(-4,-54), S(-1,-44), S( 0,-30) }
+    },
+    { // King
+      { S(291, 28), S(344, 76), S(294,103), S(219,112) },
+      { S(289, 70), S(329,119), S(263,170), S(205,159) },
+      { S(226,109), S(271,164), S(202,195), S(136,191) },
+      { S(204,131), S(212,194), S(175,194), S(137,204) },
+      { S(177,132), S(205,187), S(143,224), S( 94,227) },
+      { S(147,118), S(188,178), S(113,199), S( 70,197) },
+      { S(116, 72), S(158,121), S( 93,142), S( 48,161) },
+      { S( 94, 30), S(120, 76), S( 78,101), S( 31,111) }
     }
   },
 #endif

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,6 +81,9 @@ namespace {
 #ifdef KOTH
   { 483, 570, 603, 554 },
 #endif
+#ifdef LOSERS
+  { 1932, 2280, 2412, 2216 },
+#endif
 #ifdef RACE
   { 1017, 986, 1017, 990 },
 #endif
@@ -107,6 +110,9 @@ namespace {
 #endif
 #ifdef KOTH
   150,
+#endif
+#ifdef LOSERS
+  600,
 #endif
 #ifdef RACE
   365,
@@ -323,6 +329,10 @@ void MainThread::search() {
 #ifdef KOTH
       if (rootPos.is_koth() && rootPos.is_koth_loss())
           score = -VALUE_MATE;
+#endif
+#ifdef LOSERS
+      if (rootPos.is_losers())
+          score = rootPos.is_losers_loss() ? -VALUE_MATE : VALUE_MATE;
 #endif
 #ifdef RACE
       if (rootPos.is_race())
@@ -680,6 +690,16 @@ namespace {
                 return mated_in(ss->ply);
         }
 #endif
+#ifdef LOSERS
+        // Check for an instant win/loss (Losers)
+        if (pos.is_losers())
+        {
+            if (pos.is_losers_win())
+                return mate_in(ss->ply + 1);
+            if (pos.is_losers_loss())
+                return mated_in(ss->ply);
+        }
+#endif
 #ifdef RACE
         // Check for an instant win/loss (Racing Kings)
         if (pos.is_race())
@@ -781,6 +801,9 @@ namespace {
     // Step 4a. Tablebase probe
 #ifdef KOTH
     if (pos.is_koth()) {} else
+#endif
+#ifdef LOSERS
+    if (pos.is_losers()) {} else
 #endif
 #ifdef RACE
     if (pos.is_race()) {} else
@@ -1300,6 +1323,11 @@ moves_loop: // When in check search starts from here
             bestValue = excludedMove ? alpha : mated_in(ss->ply);
         else
 #endif
+#ifdef LOSERS
+        if (pos.is_losers() && pos.is_losers_loss())
+            bestValue = excludedMove ? alpha : mate_in(ss->ply+1);
+        else
+#endif
 #ifdef ANTI
         if (pos.is_anti())
             bestValue = excludedMove ? alpha
@@ -1384,6 +1412,16 @@ moves_loop: // When in check search starts from here
         if (pos.is_koth_win())
             return mate_in(ss->ply+1);
         if (pos.is_koth_loss())
+            return mated_in(ss->ply);
+    }
+#endif
+#ifdef LOSERS
+    // Check for an instant win or loss (Losers)
+    if (pos.is_losers())
+    {
+        if (pos.is_losers_win())
+            return mate_in(ss->ply+1);
+        if (pos.is_losers_loss())
             return mated_in(ss->ply);
     }
 #endif

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -71,6 +71,9 @@ const char* WdlSuffixes[SUBVARIANT_NB] = {
 #ifdef KOTH
     nullptr,
 #endif
+#ifdef LOSERS
+    nullptr,
+#endif
 #ifdef RACE
     nullptr,
 #endif
@@ -97,6 +100,9 @@ const char* PawnlessWdlSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #endif
 #ifdef KOTH
+    nullptr,
+#endif
+#ifdef LOSERS
     nullptr,
 #endif
 #ifdef RACE
@@ -133,6 +139,9 @@ const char* DtzSuffixes[SUBVARIANT_NB] = {
 #ifdef KOTH
     nullptr,
 #endif
+#ifdef LOSERS
+    nullptr,
+#endif
 #ifdef RACE
     nullptr,
 #endif
@@ -165,6 +174,9 @@ const char* PawnlessDtzSuffixes[VARIANT_NB] = {
     nullptr,
 #endif
 #ifdef KOTH
+    nullptr,
+#endif
+#ifdef LOSERS
     nullptr,
 #endif
 #ifdef RACE
@@ -1551,6 +1563,12 @@ void* init(Entry& e, const Position& pos) {
             { 0x71, 0xE8, 0x23, 0x5D }
         },
 #endif
+#ifdef LOSERS
+        {
+            { 0xD7, 0x66, 0x0C, 0xA5 },
+            { 0x71, 0xE8, 0x23, 0x5D }
+        },
+#endif
 #ifdef RACE
         {
             { 0xD7, 0x66, 0x0C, 0xA5 },
@@ -1613,6 +1631,12 @@ void* init(Entry& e, const Position& pos) {
         },
 #endif
 #ifdef KOTH
+        {
+            { 0xD7, 0x66, 0x0C, 0xA5 },
+            { 0x71, 0xE8, 0x23, 0x5D }
+        },
+#endif
+#ifdef LOSERS
         {
             { 0xD7, 0x66, 0x0C, 0xA5 },
             { 0x71, 0xE8, 0x23, 0x5D }
@@ -2214,6 +2238,9 @@ bool Tablebases::root_probe(Position& pos, Search::RootMoves& rootMoves, Value& 
 #ifdef KOTH
     if (pos.is_koth()) return false;
 #endif
+#ifdef LOSERS
+    if (pos.is_losers()) return false;
+#endif
 #ifdef RACE
     if (pos.is_race()) return false;
 #endif
@@ -2360,6 +2387,9 @@ bool Tablebases::root_probe_wdl(Position& pos, Search::RootMoves& rootMoves, Val
 {
 #ifdef KOTH
     if (pos.is_koth()) return false;
+#endif
+#ifdef LOSERS
+    if (pos.is_losers()) return false;
 #endif
 #ifdef RACE
     if (pos.is_race()) return false;

--- a/src/types.h
+++ b/src/types.h
@@ -127,6 +127,9 @@ enum Variant {
 #ifdef KOTH
   KOTH_VARIANT,
 #endif
+#ifdef LOSERS
+  LOSERS_VARIANT,
+#endif
 #ifdef RACE
   RACE_VARIANT,
 #endif
@@ -166,6 +169,9 @@ static std::vector<std::string> variants = {
 #endif
 #ifdef KOTH
 "kingofthehill",
+#endif
+#ifdef LOSERS
+"losers",
 #endif
 #ifdef RACE
 "racingkings",
@@ -323,6 +329,14 @@ enum Value : int {
   BishopValueMgHill = 859,   BishopValueEgHill = 883,
   RookValueMgHill   = 1159,  RookValueEgHill   = 1289,
   QueenValueMgHill  = 2396,  QueenValueEgHill  = 2610,
+#endif
+#ifdef LOSERS
+  TempoMgLosers       = 0,     TempoEgLosers       = 0,
+  PawnValueMgLosers   = -137,  PawnValueEgLosers   = -360,
+  KnightValueMgLosers = -130,  KnightValueEgLosers = -41,
+  BishopValueMgLosers = -322,  BishopValueEgLosers = -64,
+  RookValueMgLosers   = -496,  RookValueEgLosers   =  62,
+  QueenValueMgLosers  = -187,  QueenValueEgLosers  = -318,
 #endif
 #ifdef RACE
   TempoMgRace       = 0,     TempoEgRace       = 0,

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -55,6 +55,9 @@ namespace {
 #ifdef KOTH
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
+#ifdef LOSERS
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+#endif
 #ifdef RACE
   "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1",
 #endif


### PR DESCRIPTION
Move generation and validation could not be verified with perft yet, because I do not have numbers to compare to. Looking at PVs (e.g. e2e4 b7b5 f1b5 b8c6 b5c6 h7h5) there apparently are bugs, so please do not merge it yet.