### PR TITLE
Change material hash key for variants

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -155,7 +155,7 @@ namespace Material {
 
 Entry* probe(const Position& pos) {
 
-  Key key = pos.material_key() ^ pos.variant();
+  Key key = pos.material_key();
   Entry* e = pos.this_thread()->materialTable[key];
 
   if (e->key == key)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -538,8 +538,7 @@ void Position::set_check_info(StateInfo* si) const {
 
 void Position::set_state(StateInfo* si) const {
 
-  si->key = si->materialKey = 0;
-  si->key ^= Zobrist::variant[var];
+  si->key = si->materialKey = Zobrist::variant[var];
   si->pawnKey = Zobrist::noPawns;
   si->nonPawnMaterial[WHITE] = si->nonPawnMaterial[BLACK] = VALUE_ZERO;
   si->psq = SCORE_ZERO;


### PR DESCRIPTION
I think this is a slightly more clean way to avoid collisions.