### PR TITLE
Skip early pruning if we can capture in losers

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -940,6 +940,10 @@ namespace {
     if (pos.is_anti() && pos.can_capture())
         goto moves_loop;
 #endif
+#ifdef LOSERS
+    if (pos.is_losers() && pos.can_capture_losers())
+        goto moves_loop;
+#endif
 
     if (skipEarlyPruning)
         goto moves_loop;


### PR DESCRIPTION
By analogy with antichess search changes.

STC 10+0.1
LLR: 2.98 (-2.94,2.94) [0.00,10.00]
Total: 136 W: 103 L: 16 D: 17

LTC 30+0.3
LLR: 3.00 (-2.94,2.94) [0.00,10.00]
Total: 110 W: 86 L: 7 D: 17