### PR TITLE
Fix #192

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1335,8 +1335,8 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
 #ifdef CRAZYHOUSE
   if (type_of(m) == DROP)
   {
-      k ^= Zobrist::psq[pc][to] ^ Zobrist::inHand[pc][pieceCountInHand[color_of(pc)][type_of(pc)]]
-          ^ Zobrist::inHand[pc][pieceCountInHand[color_of(pc)][type_of(pc)] + 1];
+      k ^= Zobrist::psq[pc][to] ^ Zobrist::inHand[pc][pieceCountInHand[color_of(pc)][type_of(pc)] - 1]
+          ^ Zobrist::inHand[pc][pieceCountInHand[color_of(pc)][type_of(pc)]];
       if (type_of(pc) != PAWN)
           st->nonPawnMaterial[us] += PieceValue[CHESS_VARIANT][MG][type_of(pc)];
   }


### PR DESCRIPTION
The same commands as in https://github.com/ddugovic/Stockfish/issues/192#issuecomment-270005099 now return a correct result.
```
setoption name UCI_Variant value crazyhouse
position fen r1bk3r/pppp1Bpp/2n5/4p1N1/4P3/3Pb3/PPPBp1PP/RNK4Q[PNRq] b - - 0 19
d
position fen r1bk3r/pppp1Bpp/2n5/4p1N1/4P3/3Pb3/PPPBp1PP/RNK4Q[PNRq] b - - 0 19 moves Q@f1 R@e1 f1h1 e1h1 Q@f1 Q@e1 f1h1 e1h1 R@f1 Q@e1 f1h1 e1h1
d
info string variant crazyhouse startpos rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1

 +---+---+---+---+---+---+---+---+
 | r |   | b | k |   |   |   | r |
 +---+---+---+---+---+---+---+---+
 | p | p | p | p |   | B | p | p |
 +---+---+---+---+---+---+---+---+
 |   |   | n |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   | p |   | N |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   | P |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   | P | b |   |   |   |
 +---+---+---+---+---+---+---+---+
 | P | P | P | B | p |   | P | P |
 +---+---+---+---+---+---+---+---+
 | R | N | K |   |   |   |   | Q |
 +---+---+---+---+---+---+---+---+

Fen: r1bk3r/pppp1Bpp/2n5/4p1N1/4P3/3Pb3/PPPBp1PP/RNK4Q[RNPq] b - - 0 19
Key: EB3CF3A23653E172
Checkers: 

 +---+---+---+---+---+---+---+---+
 | r |   | b | k |   |   |   | r |
 +---+---+---+---+---+---+---+---+
 | p | p | p | p |   | B | p | p |
 +---+---+---+---+---+---+---+---+
 |   |   | n |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   | p |   | N |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   | P |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   | P | b |   |   |   |
 +---+---+---+---+---+---+---+---+
 | P | P | P | B | p |   | P | P |
 +---+---+---+---+---+---+---+---+
 | R | N | K |   |   |   |   | Q |
 +---+---+---+---+---+---+---+---+

Fen: r1bk3r/pppp1Bpp/2n5/4p1N1/4P3/3Pb3/PPPBp1PP/RNK4Q[RNPq] b - - 0 25
Key: EB3CF3A23653E172
Checkers: 
```