### PR TITLE
Enable variant endgame functions and add an example

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -107,6 +107,10 @@ Endgames::Endgames() {
   add<CHESS_VARIANT, KBPKN>("KBPvKN");
   add<CHESS_VARIANT, KBPPKB>("KBPPvKB");
   add<CHESS_VARIANT, KRPPKRP>("KRPPvKRP");
+
+#ifdef ATOMIC
+  add<ATOMIC_VARIANT, KNNK>("KNNvK");
+#endif
 }
 
 
@@ -842,3 +846,7 @@ ScaleFactor Endgame<CHESS_VARIANT, KPKP>::operator()(const Position& pos) const 
   // it's probably at least a draw even with the pawn.
   return Bitbases::probe(wksq, psq, bksq, us) ? SCALE_FACTOR_NONE : SCALE_FACTOR_DRAW;
 }
+
+#ifdef ATOMIC
+template<> Value Endgame<ATOMIC_VARIANT, KNNK>::operator()(const Position&) const { return VALUE_DRAW; }
+#endif

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1296,30 +1296,6 @@ Value Eval::evaluate(const Position& pos) {
 
   // If we have a specialized evaluation function for the current material
   // configuration, call it and return.
-#ifdef KOTH
-  if (pos.is_koth()) {} else
-#endif
-#ifdef LOSERS
-  if (pos.is_losers()) {} else
-#endif
-#ifdef RACE
-  if (pos.is_race()) {} else
-#endif
-#ifdef THREECHECK
-  if (pos.is_three_check()) {} else
-#endif
-#ifdef HORDE
-  if (pos.is_horde()) {} else
-#endif
-#ifdef ATOMIC
-  if (pos.is_atomic()) {} else
-#endif
-#ifdef ANTI
-  if (pos.is_anti()) {} else
-#endif
-#ifdef CRAZYHOUSE
-  if (pos.is_house()) {} else
-#endif
   if (ei.me->specialized_eval_exists())
       return ei.me->evaluate(pos);
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -172,6 +172,7 @@ Entry* probe(const Position& pos) {
   if ((e->evaluationFunction = pos.this_thread()->endgames.probe<Value>(key)) != nullptr)
       return e;
 
+  if (pos.variant() == CHESS_VARIANT)
   for (Color c = WHITE; c <= BLACK; ++c)
       if (is_KXK(pos, c))
       {
@@ -189,6 +190,8 @@ Entry* probe(const Position& pos) {
       return e;
   }
 
+  if (pos.variant() == CHESS_VARIANT)
+  {
   // We didn't find any specialized scaling function, so fall back on generic
   // ones that refer to more than one material distribution. Note that in this
   // case we don't return after setting the function.
@@ -243,6 +246,7 @@ Entry* probe(const Position& pos) {
 
   if (pos.count<PAWN>(BLACK) == 1 && npm_b - npm_w <= BishopValueMg)
       e->factor[BLACK] = (uint8_t) SCALE_FACTOR_ONEPAWN;
+  }
 
   // Evaluate the material imbalance. We use PIECE_TYPE_NONE as a place holder
   // for the bishop pair "extended piece", which allows us to be more flexible

--- a/src/material.h
+++ b/src/material.h
@@ -50,30 +50,6 @@ struct Entry {
   // the position. For instance, in KBP vs K endgames, the scaling function looks
   // for rook pawns and wrong-colored bishops.
   ScaleFactor scale_factor(const Position& pos, Color c) const {
-#ifdef KOTH
-    if (pos.is_koth()) return SCALE_FACTOR_NORMAL;
-#endif
-#ifdef LOSERS
-    if (pos.is_losers()) return SCALE_FACTOR_NORMAL;
-#endif
-#ifdef RACE
-    if (pos.is_race()) return SCALE_FACTOR_NORMAL;
-#endif
-#ifdef THREECHECK
-    if (pos.is_three_check()) return SCALE_FACTOR_NORMAL;
-#endif
-#ifdef HORDE
-    if (pos.is_horde()) return SCALE_FACTOR_NORMAL;
-#endif
-#ifdef ATOMIC
-    if (pos.is_atomic()) return SCALE_FACTOR_NORMAL;
-#endif
-#ifdef ANTI
-    if (pos.is_anti()) return SCALE_FACTOR_NORMAL;
-#endif
-#ifdef CRAZYHOUSE
-    if (pos.is_house()) return SCALE_FACTOR_NORMAL;
-#endif
     ScaleFactor sf = scalingFunction[c] ? (*scalingFunction[c])(pos)
                                         :  SCALE_FACTOR_NONE;
     return sf != SCALE_FACTOR_NONE ? sf : ScaleFactor(factor[c]);


### PR DESCRIPTION
I did not indent the code inside the added if-statements (to skip generic endgame functions) in `material.cpp` to make clear what I really changed, but I can change that later. 

Sample output for the KNN vs. K example:
```
setoption name UCI_Variant value atomic
position fen 8/1k6/8/8/5NN1/8/6K1/8 w - - 0 1
eval
info string variant atomic startpos rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
      Eval term |    White    |    Black    |    Total    
                |   MG    EG  |   MG    EG  |   MG    EG  
----------------+-------------+-------------+-------------
       Material |   ---   --- |   ---   --- |  0.00  0.00 
      Imbalance |   ---   --- |   ---   --- |  0.00  0.00 
          Pawns |   ---   --- |   ---   --- |  0.00  0.00 
        Knights |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
         Bishop |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
          Rooks |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
         Queens |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
       Mobility |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
    King safety |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
        Threats |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
   Passed pawns |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
          Space |  0.00  0.00 |  0.00  0.00 |  0.00  0.00 
----------------+-------------+-------------+-------------
          Total |   ---   --- |   ---   --- |  0.00  0.00 

Total Evaluation: 0.00 (white side)
```