### PR TITLE
Add atomic endgames where the weak side has a lone king

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -109,6 +109,7 @@ Endgames::Endgames() {
   add<CHESS_VARIANT, KRPPKRP>("KRPPvKRP");
 
 #ifdef ATOMIC
+  add<ATOMIC_VARIANT, KPK>("KPvK");
   add<ATOMIC_VARIANT, KQK>("KQvK");
   add<ATOMIC_VARIANT, KNNK>("KNNvK");
 #endif
@@ -874,6 +875,28 @@ Value Endgame<ATOMIC_VARIANT, KXK>::operator()(const Position& pos) const {
          && (pos.count<KNIGHT>(strongSide) >= 2 || ((pos.pieces(strongSide, BISHOP) & DarkSquares)
                                                     && (pos.pieces(strongSide, BISHOP) & ~DarkSquares)))))
       result = std::min(result + VALUE_KNOWN_WIN, VALUE_MATE_IN_MAX_PLY - 1);
+
+  return strongSide == pos.side_to_move() ? result : -result;
+}
+
+template<>
+Value Endgame<ATOMIC_VARIANT, KPK>::operator()(const Position& pos) const {
+
+  assert(pos.variant() == ATOMIC_VARIANT);
+  assert(verify_material(pos, strongSide, VALUE_ZERO, 1));
+  assert(verify_material(pos, weakSide, VALUE_ZERO, 0));
+
+  Square winnerKSq = pos.square<KING>(strongSide);
+  Square loserKSq = pos.square<KING>(weakSide);
+
+  int dist = distance(winnerKSq, loserKSq);
+  // Draw in case of adjacent kings
+  if (dist <= (strongSide == pos.side_to_move() ? 1 : 2))
+      return VALUE_DRAW;
+
+  Value result = PawnValueEgAtomic
+                + PushAway[relative_rank(strongSide, pos.square<PAWN>(strongSide))]
+                + PushAway[dist];
 
   return strongSide == pos.side_to_move() ? result : -result;
 }

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -37,6 +37,9 @@ enum EndgameType {
 
   // Evaluation functions
 
+#ifdef ATOMIC
+  KQK,
+#endif
   KNNK,  // KNN vs K
   KXK,   // Generic "mate lone king" eval
   KBNK,  // KBN vs K

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -247,6 +247,15 @@ Entry* probe(const Position& pos) {
   if (pos.count<PAWN>(BLACK) == 1 && npm_b - npm_w <= BishopValueMg)
       e->factor[BLACK] = (uint8_t) SCALE_FACTOR_ONEPAWN;
   }
+#ifdef ATOMIC
+  else if (pos.is_atomic())
+  {
+      Value npm_w = pos.non_pawn_material(WHITE);
+      Value npm_b = pos.non_pawn_material(BLACK);
+      if (!pos.pieces(PAWN) && npm_w + npm_b <= RookValueMg)
+          e->factor[WHITE] = (uint8_t) SCALE_FACTOR_DRAW;
+  }
+#endif
 
   // Evaluate the material imbalance. We use PIECE_TYPE_NONE as a place holder
   // for the bishop pair "extended piece", which allows us to be more flexible


### PR DESCRIPTION
If the piece is a rook, bishop or knight, the game is always drawn. In case of a queen, it can be a win or draw depending on the distance of the kings.

This not only helps to correctly identify draws, but also to find mate much more quickly:
```
setoption name UCI_Variant value atomic
position fen 8/8/8/8/6k1/8/6KQ/8 w - - 0 1
go depth 20
```
executed for versions with and without this change, respectively:
```
info depth 1 seldepth 1 multipv 1 score cp 1049 nodes 31 nps 10333 tbhits 0 time 3 pv g2f1
info depth 2 seldepth 2 multipv 1 score cp 5073 nodes 155 nps 51666 tbhits 0 time 3 pv g2h1 g4f3
info depth 3 seldepth 4 multipv 1 score cp 5077 nodes 242 nps 80666 tbhits 0 time 3 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4
info depth 4 seldepth 6 multipv 1 score cp 5089 nodes 365 nps 121666 tbhits 0 time 3 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c5
info depth 5 seldepth 8 multipv 1 score cp 5102 nodes 1038 nps 259500 tbhits 0 time 4 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c5
info depth 6 seldepth 10 multipv 1 score cp 5114 nodes 2292 nps 573000 tbhits 0 time 4 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c5 e4d5 c5b4
info depth 7 seldepth 12 multipv 1 score cp 5122 nodes 4357 nps 726166 tbhits 0 time 6 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3d3 d4e5 d3d5 e5f6 d5f3 f6e6
info depth 8 seldepth 14 multipv 1 score cp 5122 nodes 6799 nps 971285 tbhits 0 time 7 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3d3 d4e5 d3d4 e5e6 d4e5 e6d7
info depth 9 seldepth 16 multipv 1 score mate 9 nodes 8383 nps 1047875 tbhits 0 time 8 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3d3 d4e5 d3d4 e5f5 d4f4 f5e6 f4e5 e6d7 e5d6 d7c8
info depth 10 seldepth 18 multipv 1 score mate 7 nodes 10189 nps 1132111 tbhits 0 time 9 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 11 seldepth 18 multipv 1 score mate 7 nodes 12030 nps 1203000 tbhits 0 time 10 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 12 seldepth 18 multipv 1 score mate 7 nodes 14907 nps 1146692 tbhits 0 time 13 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 13 seldepth 18 multipv 1 score mate 7 nodes 17178 nps 1145200 tbhits 0 time 15 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 14 seldepth 18 multipv 1 score mate 7 nodes 23218 nps 1365764 tbhits 0 time 17 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 15 seldepth 18 multipv 1 score mate 7 nodes 30103 nps 1505150 tbhits 0 time 20 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 16 seldepth 18 multipv 1 score mate 7 nodes 38978 nps 1694695 tbhits 0 time 23 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 17 seldepth 18 multipv 1 score mate 7 nodes 48769 nps 1806259 tbhits 0 time 27 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 18 seldepth 18 multipv 1 score mate 7 nodes 58490 nps 1827812 tbhits 0 time 32 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 19 seldepth 18 multipv 1 score mate 7 nodes 69214 nps 1922611 tbhits 0 time 36 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
info depth 20 seldepth 18 multipv 1 score mate 7 nodes 83926 nps 2046975 tbhits 0 time 41 pv g2h1 g4f3 h2g2 f3e3 g2f3 e3d4 f3e4 d4c3 e4d3 c3b2 d3c3 b2b1 c3b2
bestmove g2h1 ponder g4f3

info depth 1 seldepth 2 multipv 1 score cp 1203 nodes 116 nps 38666 tbhits 0 time 3 pv g2f3
info depth 2 seldepth 2 multipv 1 score cp 1247 nodes 398 nps 132666 tbhits 0 time 3 pv h2e5 g4g3 e5f4
info depth 3 seldepth 5 multipv 1 score cp 1235 nodes 1298 nps 432666 tbhits 0 time 3 pv h2e5 g4h3 e5f4
info depth 4 seldepth 5 multipv 1 score cp 1263 nodes 2216 nps 554000 tbhits 0 time 4 pv h2e5 g4h3 e5f4 h3g3
info depth 5 seldepth 6 multipv 1 score cp 1239 nodes 10332 nps 1722000 tbhits 0 time 6 pv g2f3 g4f4 f3e4 f4g5 h2f4 g5g6 f4f6 g6h5
info depth 6 seldepth 10 multipv 1 score cp 1262 nodes 20505 nps 2050500 tbhits 0 time 10 pv h2g3 g4f3 g3f4 f3f2 f4f3 f2g3 g2f1 g3g2
info depth 7 seldepth 10 multipv 1 score cp 1269 nodes 27880 nps 2144615 tbhits 0 time 13 pv h2f4 g4f3 f4d4 f3g3 g2f3 g3f4 d4e4 f4g5 e4e5 g5g4
info depth 8 seldepth 12 multipv 1 score cp 1270 nodes 35420 nps 2361333 tbhits 0 time 15 pv h2f4 g4f3 g2g3 f3g4 g3f3 g4g3 f4b4 g3h2 b4h4 h2g3
info depth 9 seldepth 14 multipv 1 score cp 1266 nodes 47478 nps 2498842 tbhits 0 time 19 pv h2f4 g4f3 g2g3 f3g4 g3f3 g4g3 f3e4 g3f3 e4d5 f3e4 d5c4 e4d5 f4d4
info depth 10 seldepth 16 multipv 1 score cp 1274 nodes 70104 nps 2596444 tbhits 0 time 27 pv h2f4 g4f3 g2g3 f3g4 g3f3 g4g3 f3g4 g3f3 g4g5 f3g4 g5g6 g4g5 f4d4 g5h5 d4g4
info depth 11 seldepth 18 multipv 1 score cp 1271 nodes 90926 nps 2674294 tbhits 0 time 34 pv h2f4 g4f3 g2g3 f3g4 g3f3 g4g3 f3g4 g3h4 g4f5 h4g5 f5e5 g5f6 f4f5 f6e6 e5d6 e6d5 f5e4
info depth 12 seldepth 18 multipv 1 score cp 1270 nodes 128024 nps 2783130 tbhits 0 time 46 pv h2f4 g4f3 g2g3 f3g4 g3f3 g4g3 f3g4 g3h4 g4h5 h4g5 f4f5 g5g6 h5g4 g6g5 f5f6 g5f4 f6e5
info depth 13 seldepth 23 multipv 1 score cp 1273 nodes 200746 nps 2867800 tbhits 0 time 70 pv h2g3 g4f3 g3f4 f3f2 f4f3 f2g3 g2f2 g3g2 f2e2 g2f2 e2f1 f2e2 f1g2 e2f2 g2g3 f2g2 g3f4 g2g3
info depth 14 seldepth 24 multipv 1 score mate 8 nodes 266134 nps 2957044 tbhits 0 time 90 pv g2h1 g4f3 h2g2 f3f4 g2f2 f4e4 f2e3 e4d5 e3d4 d5c6 d4c5 c6b7 c5c7 b7a6 c7b6
info depth 15 seldepth 24 multipv 1 score mate 8 nodes 274817 nps 2923585 tbhits 0 time 94 pv g2h1 g4f3 h2g2 f3f4 g2f2 f4e4 f2e3 e4d5 e3d4 d5c6 d4c5 c6b7 c5c7 b7a6 c7b6
info depth 16 seldepth 24 multipv 1 score mate 8 nodes 280758 nps 2924562 tbhits 0 time 96 pv g2h1 g4f3 h2g2 f3f4 g2f2 f4e4 f2e3 e4d5 e3d4 d5c6 d4c5 c6b7 c5c7 b7a6 c7b6
info depth 17 seldepth 24 multipv 1 score mate 8 nodes 288651 nps 2945418 tbhits 0 time 98 pv g2h1 g4f3 h2g2 f3f4 g2f2 f4e4 f2e3 e4d5 e3d4 d5c6 d4c5 c6b7 c5c7 b7a6 c7b6
info depth 18 seldepth 24 multipv 1 score mate 8 nodes 299836 nps 2939568 tbhits 0 time 102 pv g2h1 g4f3 h2g2 f3f4 g2f2 f4e4 f2e3 e4d5 e3d4 d5c6 d4c5 c6b7 c5c7 b7a6 c7b6
info depth 19 seldepth 24 multipv 1 score mate 8 nodes 316721 nps 2932601 tbhits 0 time 108 pv g2h1 g4f3 h2g2 f3f4 g2f2 f4e4 f2e3 e4d5 e3d4 d5c6 d4c5 c6b7 c5c7 b7a6 c7b6
info depth 20 seldepth 24 multipv 1 score mate 7 nodes 348669 nps 2954822 tbhits 0 time 118 pv g2h1 g4f3 h2g2 f3f4 g2f3 f4e5 f3e4 e5f6 e4e5 f6g6 e5f6 g6h7 f6g7
bestmove g2h1 ponder g4f3
```

Thanks again @ddugovic for making this possible with https://github.com/ddugovic/Stockfish/commit/e2c8070daba814370e2329c7342da1231fe3d6af.