### PR TITLE
Fix evaluation of checkmate during qsearch in losers chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1552,7 +1552,7 @@ moves_loop: // When in check search starts from here
     // All legal moves have been searched. A special case: If we're in check
     // and no legal moves were found, it is checkmate.
     if (InCheck && bestValue == -VALUE_INFINITE)
-        return mated_in(ss->ply); // Plies to mate from the root
+        return pos.checkmate_value(ss->ply); // Plies to mate from the root
 
     tte->save(posKey, value_to_tt(bestValue, ss->ply),
               PvNode && bestValue > oldAlpha ? BOUND_EXACT : BOUND_UPPER,


### PR DESCRIPTION
Since losers is the only variant that evaluates checkmate differently, it is the only variant affected by this.