### PR TITLE
Fix tablebase probing for subvariants

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -151,7 +151,7 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
   {
       StateInfo st;
       Position p;
-      p.set(pos.fen(), pos.is_chess960(), pos.variant(), &st, pos.this_thread());
+      p.set(pos.fen(), pos.is_chess960(), pos.subvariant(), &st, pos.this_thread());
       Tablebases::ProbeState s1, s2;
       Tablebases::WDLScore wdl = Tablebases::probe_wdl(p, &s1);
       int dtz = Tablebases::probe_dtz(p, &s2);
@@ -257,24 +257,7 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
   std::fill_n(&pieceList[0][0], sizeof(pieceList) / sizeof(Square), SQ_NONE);
   st = si;
   subvar = v;
-  if (v < VARIANT_NB)
-      var = v;
-  else
-      switch(v)
-      {
-#ifdef SUICIDE
-      case SUICIDE_VARIANT:
-          var = ANTI_VARIANT;
-          break;
-#endif
-#ifdef LOOP
-      case LOOP_VARIANT:
-          var = CRAZYHOUSE_VARIANT;
-          break;
-#endif
-      default:
-          assert(false);
-      }
+  var = main_variant(v);
 
   ss >> std::noskipws;
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1749,8 +1749,8 @@ T probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw) {
     if (pos.is_variant_end())
         return result_to_score<T>(pos.variant_result());
 
-    // Check for checkmate and stalemate
-    if (MoveList<LEGAL>(pos).size() == 0)
+    // Check for checkmate and stalemate in variants
+    if (pos.variant() != CHESS_VARIANT && MoveList<LEGAL>(pos).size() == 0)
         return result_to_score<T>(pos.checkers() ? pos.checkmate_value() : pos.stalemate_value());
 
     if (!(pos.pieces() ^ pos.pieces(KING)))

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1753,6 +1753,9 @@ T probe_table(const Position& pos, ProbeState* result, WDLScore wdl = WDLDraw) {
     if (pos.variant() != CHESS_VARIANT && MoveList<LEGAL>(pos).size() == 0)
         return result_to_score<T>(pos.checkers() ? pos.checkmate_value() : pos.stalemate_value());
 
+#ifdef ANTI
+    if (!pos.is_anti())
+#endif
     if (!(pos.pieces() ^ pos.pieces(KING)))
         return T(WDLDraw); // KvK
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -121,7 +121,7 @@ const char* PawnlessWdlSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #endif
 #ifdef SUICIDE
-    ".stbw",
+    ".gtbw",
 #endif
 #ifdef LOOP
     nullptr,
@@ -195,7 +195,7 @@ const char* PawnlessDtzSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #endif
 #ifdef SUICIDE
-    ".stbz",
+    ".gtbz",
 #endif
 #ifdef LOOP
     nullptr,
@@ -1674,8 +1674,8 @@ void* init(Entry& e, const Position& pos) {
 #endif
 #ifdef SUICIDE
         {
-            { 0xE4, 0xCF, 0xE7, 0x23 },
-            { 0x7B, 0xF6, 0x93, 0x15 }
+            { 0xD6, 0xF5, 0x1B, 0x50 },
+            { 0xBC, 0x55, 0xBC, 0x21 }
         },
 #endif
 #ifdef LOOP

--- a/src/types.h
+++ b/src/types.h
@@ -628,4 +628,23 @@ inline bool is_ok(Move m) {
   return from_sq(m) != to_sq(m); // Catch MOVE_NULL and MOVE_NONE
 }
 
+inline Variant main_variant(Variant v) {
+  if (v < VARIANT_NB)
+      return v;
+  switch(v)
+  {
+#ifdef SUICIDE
+  case SUICIDE_VARIANT:
+      return ANTI_VARIANT;
+#endif
+#ifdef LOOP
+  case LOOP_VARIANT:
+      return CRAZYHOUSE_VARIANT;
+#endif
+  default:
+      assert(false);
+      return CHESS_VARIANT; // Silence a warning
+  }
+}
+
 #endif // #ifndef TYPES_H_INCLUDED


### PR DESCRIPTION
So far the tablebases of the main variant were probed, which is not correct for suicide chess.

This also generalizes parts of the probing code, so that less changes are necessary if new variant tablebases are added.

Credits to @niklasf for his similar PR #206 that contained some additional ideas that I added to this PR.