### PR TITLE
Tweak passed pawn evaluation for atomic chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1068,6 +1068,11 @@ namespace {
 #ifdef ANTI
             if (pos.is_anti()) {} else
 #endif
+#ifdef ATOMIC
+            if (pos.is_atomic())
+                ebonus +=  distance(pos.square<KING>(Them), blockSq) * 5 * rr;
+            else
+#endif
             {
             // Adjust bonus based on the king's proximity
             ebonus +=  distance(pos.square<KING>(Them), blockSq) * 5 * rr


### PR DESCRIPTION
Remove dependence on distance from own king, since the king can not support a passed pawn in atomic chess.

STC 10+0.1
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 600 W: 255 L: 168 D: 177

LTC 30+0.3
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 448 W: 197 L: 113 D: 138