### PR TITLE
Tweak crazyhouse SEE

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1746,6 +1746,10 @@ Value Position::see<ATOMIC_VARIANT>(Move m) const {
 bool Position::see_ge(Move m, Value v) const {
 
   assert(is_ok(m));
+#ifdef CRAZYHOUSE
+  if (is_house())
+      v /= 2;
+#endif
 
 #ifdef THREECHECK
   if (is_three_check() && gives_check(m))


### PR DESCRIPTION
Take into account that each capture changes the evaluation by two times the piece value by halving the cutoff of see_ge.

STC 10+0.1
LLR: 2.99 (-2.94,2.94) [0.00,10.00]
Total: 2288 W: 1168 L: 1035 D: 85

LTC 30+0.3
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 4728 W: 2350 L: 2183 D: 195