### PR TITLE
Reduce pruning at shallow depth in giveaway

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1084,6 +1084,9 @@ moves_loop: // When in check search starts from here
       {
           if (   !captureOrPromotion
               && !givesCheck
+#ifdef ANTI
+              && (!pos.is_anti() || !(pos.attackers_to(to_sq(move)) & pos.pieces(~pos.side_to_move())))
+#endif
               && !pos.advanced_pawn_push(move))
           {
               // Move count based pruning


### PR DESCRIPTION
Apply less aggressive pruning if a piece moves to an attacked square, hence forcing a capture.

STC 10+0.1
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 792 W: 261 L: 181 D: 350

LTC 30+0.3
LLR: 2.98 (-2.94,2.94) [0.00,10.00]
Total: 710 W: 214 L: 138 D: 358