### PR TITLE
Use lazy evaluation only for standard chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1479,6 +1479,7 @@ Value Eval::evaluate(const Position& pos) {
   // We have taken into account all cheap evaluation terms.
   // If score exceeds a threshold return a lazy evaluation.
   Value lazy = lazy_eval(mg_value(score), eg_value(score));
+  if (pos.variant() == CHESS_VARIANT)
   if (lazy)
       return pos.side_to_move() == WHITE ? lazy : -lazy;
 


### PR DESCRIPTION
As far as I understand, the improvement by the lazy evaluation patch is due to a time-saving by skipping large parts of the evaluation function. Since this is risky for variants and at most might improve playing strength by a few Elo, but at worst could regress it by several hundred Elo, I propose to only use it for standard chess.