### PR TITLE
Use normal scale factor in atomic chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1404,6 +1404,9 @@ namespace {
 
     // If we don't already have an unusual scale factor, check for certain
     // types of endgames, and use a lower scale for those.
+#ifdef ATOMIC
+    if (pos.is_atomic()) {} else
+#endif
     if (    ei.me->game_phase() < PHASE_MIDGAME
         && (sf == SCALE_FACTOR_NORMAL || sf == SCALE_FACTOR_ONEPAWN))
     {


### PR DESCRIPTION
Do not use standard chess specific scale factors for atomic chess endgames.

STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 4614 W: 1575 L: 1440 D: 1599

LTC
LLR: 2.98 (-2.94,2.94) [0.00,10.00]
Total: 3738 W: 1201 L: 1081 D: 1456