### PR TITLE
Allow variant as optional argument to bench command

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -305,7 +305,7 @@ const int default_depth[SUBVARIANT_NB] = {
   13,
 #endif
 #ifdef CRAZYHOUSE
-  13,
+  12,
 #endif
 #ifdef HORDE
   13,
@@ -329,10 +329,10 @@ const int default_depth[SUBVARIANT_NB] = {
   13,
 #endif
 #ifdef BUGHOUSE
-  13,
+  12,
 #endif
 #ifdef LOOP
-  13,
+  12,
 #endif
 };
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -352,8 +352,15 @@ void benchmark(const Position& current, istream& is) {
   vector<string> fens;
   Search::LimitsType limits;
 
+  uint64_t nodes = 0;
+  TimePoint elapsed = now();
+  Position pos;
+
   string varname   = (!isdigit(is.peek()) && is >> token) ? token : Options["UCI_Variant"];
-  Variant variant  = UCI::variant_from_name(varname);
+  Variant variant  = varname == "all" ? CHESS_VARIANT : UCI::variant_from_name(varname);
+  streampos args = is.tellg();
+
+  do {
 
   // Assign default values to missing arguments
   string ttSize    = (is >> token) ? token : "16";
@@ -402,10 +409,6 @@ void benchmark(const Position& current, istream& is) {
       file.close();
   }
 
-  uint64_t nodes = 0;
-  TimePoint elapsed = now();
-  Position pos;
-
   for (size_t i = 0; i < fens.size(); ++i)
   {
       StateListPtr states(new std::deque<StateInfo>(1));
@@ -424,6 +427,8 @@ void benchmark(const Position& current, istream& is) {
           nodes += Threads.nodes_searched();
       }
   }
+
+  } while (varname == "all" && ++variant < SUBVARIANT_NB && (is.clear(), is.seekg(args)));
 
   elapsed = now() - elapsed + 1; // Ensure positivity to avoid a 'divide by zero'
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -356,7 +356,7 @@ void benchmark(const Position& current, istream& is) {
   TimePoint elapsed = now();
   Position pos;
 
-  string varname   = (!isdigit(is.peek()) && is >> token) ? token : Options["UCI_Variant"];
+  string varname   = (!isdigit((is >> ws).peek()) && is >> token) ? token : Options["UCI_Variant"];
   Variant variant  = varname == "all" ? CHESS_VARIANT : UCI::variant_from_name(varname);
   streampos args = is.tellg();
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -296,6 +296,46 @@ const vector<string> Defaults[SUBVARIANT_NB] = {
 #endif
 };
 
+const int default_depth[SUBVARIANT_NB] = {
+  13,
+#ifdef ANTI
+  13,
+#endif
+#ifdef ATOMIC
+  13,
+#endif
+#ifdef CRAZYHOUSE
+  13,
+#endif
+#ifdef HORDE
+  13,
+#endif
+#ifdef KOTH
+  13,
+#endif
+#ifdef LOSERS
+  13,
+#endif
+#ifdef RACE
+  13,
+#endif
+#ifdef RELAY
+  13,
+#endif
+#ifdef THREECHECK
+  13,
+#endif
+#ifdef SUICIDE
+  13,
+#endif
+#ifdef BUGHOUSE
+  13,
+#endif
+#ifdef LOOP
+  13,
+#endif
+};
+
 } // namespace
 
 /// benchmark() runs a simple benchmark by letting Stockfish analyze a set
@@ -311,12 +351,14 @@ void benchmark(const Position& current, istream& is) {
   string token;
   vector<string> fens;
   Search::LimitsType limits;
-  Variant variant = UCI::variant_from_name(Options["UCI_Variant"]);
+
+  string varname   = (!isdigit(is.peek()) && is >> token) ? token : Options["UCI_Variant"];
+  Variant variant  = UCI::variant_from_name(varname);
 
   // Assign default values to missing arguments
   string ttSize    = (is >> token) ? token : "16";
   string threads   = (is >> token) ? token : "1";
-  string limit     = (is >> token) ? token : "13";
+  string limit     = (is >> token) ? token : to_string(default_depth[variant]);
   string fenFile   = (is >> token) ? token : "default";
   string limitType = (is >> token) ? token : "depth";
 


### PR DESCRIPTION
E.g. "bench atomic". If the word after bench starts with a digit, the current UCI_Variant option value is used and the word is instead passed to the next option to preserve compatibility to bench commands of official stockfish.

Furthermore, add an array of default depths to be able to account for different run times of benchmarks in variants.

I intend to add an option to run over all variants (if the variant name is, e.g., "all") in order to be able to check whether there is a functional change in *any* variant.