### PR TITLE
Higher HSHMAX needed for 6 piece antichess tables

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -535,7 +535,7 @@ class HashTable {
 #endif
 
 #if defined(ANTI)
-    static const int HSHMAX     = 12;
+    static const int HSHMAX     = 14;
 #elif defined(ATOMIC)
     static const int HSHMAX     = 8;
 #else


### PR DESCRIPTION
Finally my 6 piece suicide tablebase generation project is complete: http://www.talkchess.com/forum/viewtopic.php?p=703256#703256

As it turns out a higher HSHMAX is required to hold all the 8400 tables in the hashtable.