### PR TITLE
Hide currmove output by default

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1019,11 +1019,12 @@ moves_loop: // When in check search starts from here
           continue;
 
       ss->moveCount = ++moveCount;
-
+#ifdef PRINTCURRMOVE
       if (rootNode && thisThread == Threads.main() && Time.elapsed() > 3000)
           sync_cout << "info depth " << depth / ONE_PLY
                     << " currmove " << UCI::move(move, pos.is_chess960())
                     << " currmovenumber " << moveCount + thisThread->PVIdx << sync_endl;
+#endif
 
       if (PvNode)
           (ss+1)->pv = nullptr;


### PR DESCRIPTION
It makes it harder to follow useful stockfish output, and libraries ignore it.