### PR TITLE
Redefine game phase in horde chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1447,6 +1447,12 @@ namespace {
                  && !pos.pawn_passed(~strongSide, pos.square<KING>(~strongSide)))
             sf = ScaleFactor(37 + 7 * pos.count<PAWN>(strongSide));
     }
+#ifdef HORDE
+    if (   pos.is_horde()
+        && pos.non_pawn_material(pos.is_horde_color(WHITE) ? WHITE : BLACK) >= QueenValueMg
+        && !pos.is_horde_color(strongSide))
+        sf = ScaleFactor(10);
+#endif
 
     return sf;
   }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -712,7 +712,7 @@ Phase Position::game_phase() const {
   Value npm = st->nonPawnMaterial[WHITE] + st->nonPawnMaterial[BLACK];
 #ifdef HORDE
   if (is_horde())
-      npm = 2 * st->nonPawnMaterial[is_horde_color(WHITE) ? BLACK : WHITE];
+      return Phase(count<PAWN>(is_horde_color(WHITE) ? WHITE : BLACK) * PHASE_MIDGAME / 36);
 #endif
 
   npm = std::max(PhaseLimit[variant()][EG], std::min(npm, PhaseLimit[variant()][MG]));


### PR DESCRIPTION
Redefine the game phase in horde chess using the number of pawns of the horde. This plays nicely with scale factors when the horde has promoted pieces.

STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 1504 W: 797 L: 675 D: 32

LTC
LLR: 3.00 (-2.94,2.94) [0.00,10.00]
Total: 2610 W: 1352 L: 1212 D: 46