### PR TITLE
Add giveaway endgame functions for RvK, KvN, NvN

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -37,6 +37,11 @@ enum EndgameType {
 
   // Evaluation functions
 
+#ifdef ANTI
+  RK,
+  KN,
+  NN,
+#endif
 #ifdef ATOMIC
   KQK,
 #endif

--- a/src/position.h
+++ b/src/position.h
@@ -356,7 +356,7 @@ template<PieceType Pt> inline Square Position::square(Color c) const {
 #endif
 #ifdef ANTI
   // There may be zero, one, or multiple kings
-  if (is_anti() && Pt == KING)
+  if (is_anti() && pieceCount[make_piece(c, Pt)] == 0)
       return SQ_NONE;
 #endif
   assert(pieceCount[make_piece(c, Pt)] == 1);


### PR DESCRIPTION
Since these endgames functions are triggered very rarely, it is difficult to prove a clear improvement. However, the patch consistently achieves a positive score against master and it should be very useful for analysis in endgames.

STC
LLR: 2.99 (-2.94,2.94) [0.00,10.00]
Total: 3412 W: 924 L: 817 D: 1671

LTC
LLR: -0.28 (-2.94,2.94) [0.00,10.00]
Total: 5000 W: 1222 L: 1176 D: 2602