### PR TITLE
Tweak pruning in horde chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1108,7 +1108,12 @@ moves_loop: // When in check search starts from here
 #ifdef ANTI
               && (!pos.is_anti() || !(pos.attackers_to(to_sq(move)) & pos.pieces(~pos.side_to_move())))
 #endif
-              && !pos.advanced_pawn_push(move))
+#ifdef HORDE
+              && (pos.is_horde() || !pos.advanced_pawn_push(move))
+#else
+              && !pos.advanced_pawn_push(move)
+#endif
+          )
           {
               // Move count based pruning
               if (moveCountPruning)


### PR DESCRIPTION
Since there are so many advanced pawn pushes in horde chess, do not prevent them from being pruned.

STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 2041 W: 1078 L: 947 D: 16

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 1908 W: 1010 L: 881 D: 17