### PR TITLE
Only print one PV at the end.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -389,7 +389,7 @@ void MainThread::search() {
           if (scoreDiff > 0 && depthDiff >= 0)
               bestThread = th;
 #ifdef USELONGESTPV
-          longestPlies = std::max(bestThread->rootMoves[0].pv.size(), longestPlies);
+          longestPlies = std::max(th->rootMoves[0].pv.size(), longestPlies);
 #endif
       }
 
@@ -436,13 +436,12 @@ void MainThread::search() {
 
   previousScore = bestThread->rootMoves[0].score;
 
-  // Send new PV when needed
+// Send new PV when needed
+#ifndef USELONGESTPV
   if (bestThread != this)
       sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
-
-#ifdef USELONGESTPV
-  // Send longer PV when needed
-  if (longestPVThread != bestThread)
+#else
+  if (longestPVThread != this)
       sync_cout << UCI::pv(longestPVThread->rootPos, longestPVThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 #endif
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -436,13 +436,13 @@ void MainThread::search() {
 
   previousScore = bestThread->rootMoves[0].score;
 
-// Send new PV when needed
-#ifndef USELONGESTPV
-  if (bestThread != this)
-      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
-#else
+#ifdef USELONGESTPV
   if (longestPVThread != this)
       sync_cout << UCI::pv(longestPVThread->rootPos, longestPVThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
+#else
+  // Send new PV when needed
+  if (bestThread != this)
+      sync_cout << UCI::pv(bestThread->rootPos, bestThread->completedDepth, -VALUE_INFINITE, VALUE_INFINITE) << sync_endl;
 #endif
 
   // Best move could be MOVE_NONE when searching on a terminal position


### PR DESCRIPTION
Based on a discussion with @niklasf and @isaacl we decided that printing BOTH the bestThread and longestPVThread at the end of the search was bad for  UI related reasons. It will flicker a shorter PV quickly and then switch to the longer one immediately afterwards.  There is no real point to printing out the shorter PV in addition to the longer PV.

While in there I noticed what I think is a bug in the changes you made to the algorithm. Notably, if bestThread is set during the first loop, it's short (say 1 ply) there are other threads that are longer, but aren't "best" according to stockfish, then longestPlies will be set to 1. 

The effect of this is that the subsequent search for a longer PV will never be hit, because this line will fail:
` if (bestThread->rootMoves[0].pv.size() < std::min(minPlies, longestPlies))` Because `std::min(6,1) == 1` and `bestThread->rootMoves[0].pv.size() == 1`
