### PR TITLE
Fix #239: move generation in losers chess

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -603,7 +603,7 @@ inline bool Position::can_capture_losers() const {
       if (type_of(piece_on(s)) == KING)
       {
           while (attacked)
-              if (!(attackers_to(pop_lsb(&attacked)) & pieces(~sideToMove)))
+              if (!(attackers_to(pop_lsb(&attacked), pieces() ^ square<KING>(sideToMove)) & pieces(~sideToMove)))
                   return true;
       }
       // If we are in check, any legal capture has to remove the checking piece


### PR DESCRIPTION
If the king has a possible capture when in check, the king itself has to be removed when checking for attackers to the captured piece. See #239 for an example.