### PR TITLE
Tweak material evaluation for horde chess

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -206,13 +206,13 @@ namespace {
     {
       //           THEIR PIECES
       // pair pawn knight bishop rook queen king
-      { 0                                      }, // Bishop pair
-      { 0,    0                                }, // Pawn
-      { 0,    0,   0                           }, // Knight      OUR PIECES
-      { 0,    0,   0,     0                    }, // Bishop
-      { 0,    0,   0,     0,     0             }, // Rook
-      { 0,    0,   0,     0,     0,   0        }, // Queen
-      { 0,    0,   0,     0,     0,   0,    0  }  // King
+      { 0                                       }, // Bishop pair
+      { 0,     0                                }, // Pawn
+      { 0,     0,     0                         }, // Knight      OUR PIECES
+      { 0,     0,     0,     0                  }, // Bishop
+      { 0,     0,     0,     0,     0           }, // Rook
+      { 0,     0,     0,     0,     0,    0     }, // Queen
+      { 0,  -789,  -872,   -19,  -416, -594,  0 }  // King
     },
 #endif
 #ifdef KOTH

--- a/src/types.h
+++ b/src/types.h
@@ -321,12 +321,12 @@ enum Value : int {
 #endif
 #ifdef HORDE
   TempoMgHorde       = 0,     TempoEgHorde       = 0,
-  PawnValueMgHorde   = 370,   PawnValueEgHorde   = 360,
-  KnightValueMgHorde = 825,   KnightValueEgHorde = 928,
-  BishopValueMgHorde = 779,   BishopValueEgHorde = 980,
-  RookValueMgHorde   = 1037,  RookValueEgHorde   = 1122,
-  QueenValueMgHorde  = 2715,  QueenValueEgHorde  = 3005,
-  KingValueMgHorde   = 2111,  KingValueEgHorde   = 964,
+  PawnValueMgHorde   = 317,   PawnValueEgHorde   = 316,
+  KnightValueMgHorde = 885,   KnightValueEgHorde = 985,
+  BishopValueMgHorde = 745,   BishopValueEgHorde = 964,
+  RookValueMgHorde   = 1060,  RookValueEgHorde   = 1187,
+  QueenValueMgHorde  = 3107,  QueenValueEgHorde  = 3266,
+  KingValueMgHorde   = 2296,  KingValueEgHorde   = 995,
 #endif
 #ifdef KOTH
   TempoMgHill       = 1,     TempoEgHill       = 1,


### PR DESCRIPTION
Introduce asymmetric piece values by using the fact that the horde does not have a king.

STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 9151 W: 4643 L: 4410 D: 98
http://35.161.250.236:6543/tests/view/58971a186e23db014ac09fa9

LTC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 962 W: 531 L: 416 D: 15
http://35.161.250.236:6543/tests/view/5899b85a6e23db014ac09fdc