### PR TITLE
Simplify away threats evaluation for atomic chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -989,6 +989,12 @@ namespace {
     }
     else
 #endif
+#ifdef ATOMIC
+    if (pos.is_atomic())
+    {
+    }
+    else
+#endif
 #ifdef LOSERS
     if (pos.is_losers())
     {
@@ -1031,20 +1037,12 @@ namespace {
 #endif
     {
 
-#ifdef ATOMIC
-    if (pos.is_atomic()) {} else
-#endif
     // Small bonus if the opponent has loose pawns or pieces
     if (   (pos.pieces(Them) ^ pos.pieces(Them, QUEEN, KING))
         & ~(ei.attackedBy[Us][ALL_PIECES] | ei.attackedBy[Them][ALL_PIECES]))
         score += LooseEnemies;
 
     // Non-pawn enemies attacked by a pawn
-#ifdef ATOMIC
-    if (pos.is_atomic())
-        weak = 0;
-    else
-#endif
     weak = (pos.pieces(Them) ^ pos.pieces(Them, PAWN)) & ei.attackedBy[Us][PAWN];
 
     if (weak)
@@ -1062,19 +1060,9 @@ namespace {
     }
 
     // Non-pawn enemies defended by a pawn
-#ifdef ATOMIC
-    if (pos.is_atomic())
-        defended = pos.pieces(Them) ^ pos.pieces(Them, PAWN);
-    else
-#endif
     defended = (pos.pieces(Them) ^ pos.pieces(Them, PAWN)) & ei.attackedBy[Them][PAWN];
 
     // Enemies not defended by a pawn and under our attack
-#ifdef ATOMIC
-    if (pos.is_atomic())
-        weak = 0;
-    else
-#endif
     weak =   pos.pieces(Them)
           & ~ei.attackedBy[Them][PAWN]
           &  ei.attackedBy[Us][ALL_PIECES];
@@ -1103,9 +1091,6 @@ namespace {
         score += Hanging * popcount(weak & ~ei.attackedBy[Them][ALL_PIECES]);
 
         b = weak & ei.attackedBy[Us][KING];
-#ifdef ATOMIC
-        if (pos.is_atomic()) {} else
-#endif
         if (b)
             score += ThreatByKing[more_than_one(b)];
     }
@@ -1114,11 +1099,6 @@ namespace {
     b = pos.pieces(Us, PAWN) & ~TRank7BB;
     b = shift<Up>(b | (shift<Up>(b & TRank2BB) & ~pos.pieces()));
 
-#ifdef ATOMIC
-    if (pos.is_atomic())
-        b &=  ~pos.pieces();
-    else
-#endif
     b &=  ~pos.pieces()
         & ~ei.attackedBy[Them][PAWN]
         & (ei.attackedBy[Us][ALL_PIECES] | ~ei.attackedBy[Them][ALL_PIECES]);


### PR DESCRIPTION
I intend to add a threat evaluation for atomic chess based on shifting bitboards to account for explosions, but for now simply removing the current threats evaluation performs quite well.

STC
LLR: 2.97 (-2.94,2.94) [-6.00,2.00]
Total: 1114 W: 408 L: 318 D: 388
http://35.161.250.236:6543/tests/view/589c71be6e23db014ac0a00f

LTC
LLR: 2.96 (-2.94,2.94) [-6.00,2.00]
Total: 1461 W: 483 L: 398 D: 580
http://35.161.250.236:6543/tests/view/589c82bd6e23db014ac0a015