### PR TITLE
Fix en passant capturing check evasions for losers

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -584,8 +584,9 @@ inline bool Position::is_losers_win() const {
 
 inline bool Position::can_capture_losers() const {
   // En passent captures
-  if (ep_square() != SQ_NONE && !checkers())
-      if (attackers_to(ep_square()) & pieces(sideToMove, PAWN) & ~pinned_pieces(sideToMove))
+  if (ep_square() != SQ_NONE
+      && (attackers_to(ep_square()) & pieces(sideToMove, PAWN) & ~pinned_pieces(sideToMove))
+      && !(checkers() - (ep_square() + (sideToMove == WHITE ? SOUTH : NORTH))))
           return true;
   Bitboard b = pieces(sideToMove);
   // Double check forces the king to move


### PR DESCRIPTION
This fixes incorrect move generation in positions like `8/8/8/2k1K3/2pP4/8/8/8 b - d3 0 1`.

position:
```
 +---+---+---+---+---+---+---+---+
 |   |   |   |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   | k |   | K |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   | p | P |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+
 |   |   |   |   |   |   |   |   |
 +---+---+---+---+---+---+---+---+

Fen: 8/8/8/2k1K3/2pP4/8/8/8 b - d3 0 1
Key: 37DD4708E56FC6E0
Checkers: d4 
```


without fix:
```
Position: 1/1
c5b4: 1
c4d3: 1
c5b5: 1
c5c6: 1
c5b6: 1

===========================
Total time (ms) : 10
Nodes searched  : 5
Nodes/second    : 500
```

with fix:
```
Position: 1/1
c4d3: 1

===========================
Total time (ms) : 9
Nodes searched  : 1
Nodes/second    : 111
```