### PR TITLE
Change move encoding to fit into 16 bits

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -955,6 +955,11 @@ bool Position::pseudo_legal(const Move m) const {
       return MoveList<LEGAL>(*this).contains(m);
 
   // Is not a promotion, so promotion piece must be empty
+#ifdef CRAZYHOUSE
+  if (type_of(m) == DROP)
+      assert(promotion_type(m) - KNIGHT == 1);
+  else
+#endif
   if (promotion_type(m) - KNIGHT != NO_PIECE_TYPE)
       return false;
 


### PR DESCRIPTION
This fixes the TT issue pointed out in #103. It is a significant improvement for crazyhouse and no regression for giveaway and standard chess. Credit to @isaacl for [his idea on a nice speed-up](https://github.com/ianfab/Stockfish/commit/ed12559212093e664a66ec5d3c9f5e28ef17fdb7#commitcomment-20859051).

The test results of the first version can be found in the commit message. In the following, I give the numbers of a series of benchmark tests (bench chess 128 1 15) to compare current master, the tested version and the improved version:
```
master:
Total time (ms) : 8419
Nodes searched  : 14201131
Nodes/second    : 1686795

Total time (ms) : 8621
Nodes searched  : 14201131
Nodes/second    : 1647271

Total time (ms) : 8427
Nodes searched  : 14201131
Nodes/second    : 1685194


tested version:
Total time (ms) : 8572
Nodes searched  : 14201131
Nodes/second    : 1656688

Total time (ms) : 8568
Nodes searched  : 14201131
Nodes/second    : 1657461

Total time (ms) : 8646
Nodes searched  : 14201131
Nodes/second    : 1642508


improved version:
Total time (ms) : 8298
Nodes searched  : 14201131
Nodes/second    : 1711392

Total time (ms) : 8348
Nodes searched  : 14201131
Nodes/second    : 1701141

Total time (ms) : 8356
Nodes searched  : 14201131
Nodes/second    : 1699513
```