### PR TITLE
Change search extensions for giveaway

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1075,8 +1075,8 @@ moves_loop: // When in check search starts from here
 #ifdef ANTI
       if (    pos.is_anti()
           && !moveCountPruning
-          && (pos.attackers_to(to_sq(move)) & pos.pieces(~pos.side_to_move()))
-          && !pos.capture(move))
+          && pos.capture(move)
+          && MoveList<LEGAL>(pos).size() == 1)
           extension = ONE_PLY;
 #endif
 


### PR DESCRIPTION
Extend if there is only one capturing move available. This should help to correctly evaluate long forced lines.

STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 2228 W: 669 L: 572 D: 987

LTC
LLR: 2.99 (-2.94,2.94) [0.00,10.00]
Total: 1906 W: 566 L: 473 D: 867