### PR TITLE
Tweak piece values for giveaway

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -301,12 +301,12 @@ enum Value : int {
   RookValueMg   = 1285,  RookValueEg   = 1371,
   QueenValueMg  = 2513,  QueenValueEg  = 2648,
 #ifdef ANTI
-  PawnValueMgAnti   = -137,  PawnValueEgAnti   = -360,
-  KnightValueMgAnti = -130,  KnightValueEgAnti = 41,
-  BishopValueMgAnti = -322,  BishopValueEgAnti = 64,
-  RookValueMgAnti   = -496,  RookValueEgAnti   = 82,
-  QueenValueMgAnti  = -187,  QueenValueEgAnti  = -318,
-  KingValueMgAnti   = -20,   KingValueEgAnti   = 130,
+  PawnValueMgAnti   = -128,  PawnValueEgAnti   = -160,
+  KnightValueMgAnti = -161,  KnightValueEgAnti = 193,
+  BishopValueMgAnti = -351,  BishopValueEgAnti = 118,
+  RookValueMgAnti   = -541,  RookValueEgAnti   = 58,
+  QueenValueMgAnti  = -121,  QueenValueEgAnti  = -224,
+  KingValueMgAnti   = -23,   KingValueEgAnti   = 231,
 #endif
 #ifdef ATOMIC
   PawnValueMgAtomic   = 329,   PawnValueEgAtomic   = 437,


### PR DESCRIPTION
STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 552 W: 254 L: 164 D: 134

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 316 W: 164 L: 78 D: 74

This seems to be a quite big improvement. The piece values look more natural now with many positive values in the endgame, especially when taking into account mobility bonuses. Furthermore, it finds good opening moves much more quickly, e.g. in the starting position (finding 1. e3 quickly) or after 1. e3 b5 2. Bxb5, since it discards Bb7 after ~200ms (on one core) and prefers Ba6 and e6, the two "best" (largest proof tree) moves. This might be fast enough for level 8 on lichess to not play Bb7.