### PR TITLE
Tweak pruning margins for losers chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,7 +82,7 @@ namespace {
   { 483, 570, 603, 554 },
 #endif
 #ifdef LOSERS
-  { 1932, 2280, 2412, 2216 },
+  { 1981, 2335, 2351, 2142 },
 #endif
 #ifdef RACE
   { 1017, 986, 1017, 990 },
@@ -112,7 +112,7 @@ namespace {
   150,
 #endif
 #ifdef LOSERS
-  600,
+  593,
 #endif
 #ifdef RACE
   365,
@@ -143,7 +143,7 @@ namespace {
   { 256, 200 },
 #endif
 #ifdef LOSERS
-  { 256, 200 },
+  { 299, 281 },
 #endif
 #ifdef RACE
   { 256, 200 },


### PR DESCRIPTION
STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 2034 W: 949 L: 829 D: 256
http://35.161.250.236:6543/tests/view/58b37b726e23db1e9386706f

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 4088 W: 1839 L: 1691 D: 558
http://35.161.250.236:6543/tests/view/58b401406e23db1e93867075