### PR TITLE
Generate king advances as captures in racing kings

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -422,6 +422,15 @@ namespace {
     {
         Square ksq = pos.square<KING>(Us);
         Bitboard b = pos.attacks_from<KING>(ksq) & target;
+#ifdef RACE
+        if (pos.is_race())
+        {
+            if (Type == CAPTURES)
+                b |= pos.attacks_from<KING>(ksq) & passed_pawn_mask(WHITE, ksq) & ~pos.pieces();
+            if (Type == QUIETS)
+                b &= ~passed_pawn_mask(WHITE, ksq);
+        }
+#endif
 #ifdef RELAY
         if (pos.is_relay())
         {


### PR DESCRIPTION
STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 2273 W: 678 L: 581 D: 1014
http://35.161.250.236:6543/tests/view/58b37ce46e23db1e93867072

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 3197 W: 907 L: 801 D: 1489
http://35.161.250.236:6543/tests/view/58b4bfc36e23db70f822ed0b

The same "trick" is already used for queen promotions in standard chess to improve move ordering. Since SEE of king moves is at least zero, all king advances in racing kings will be picked during the stage `GOOD_CAPTURES`.