### PR TITLE
Fix segmentation fault in horde chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -641,6 +641,9 @@ namespace {
         if (pos.is_anti())
             continue;
 #endif
+#ifdef HORDE
+        if (pos.is_horde() && pos.is_horde_color(Us)) {} else
+#endif
         // Bonus for this piece as a king protector
         score += Protector[Pt][distance(s, pos.square<KING>(Us))];
 


### PR DESCRIPTION
The horde does not have a king, which caused the king distance calulation to fail, so skip the respective evaluation term.

Run `bench horde` to reproduce the segfault.