### PR TITLE
Tweak king safety related bonuses for three-check chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -382,8 +382,8 @@ namespace {
 #ifdef THREECHECK
   const Score ChecksGivenBonus[CHECKS_NB] = {
       S(0, 0),
-      S(472, 369),
-      S(1980, 1159),
+      S(508, 377),
+      S(2224, 1000),
       S(0, 0)
   };
 #endif
@@ -488,7 +488,7 @@ namespace {
     S( 7,  0),
 #endif
 #ifdef THREECHECK
-    S(15,  10),
+    S(17,  10),
 #endif
   };
   const Score PawnlessFlank       = S( 20, 80);
@@ -749,7 +749,7 @@ namespace {
     2 * int(BishopValueMg),
 #endif
 #ifdef THREECHECK
-    4 * int(BishopValueMg),
+    3264,
 #endif
   };
 


### PR DESCRIPTION
STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 2985 W: 1413 L: 1277 D: 295
http://35.161.250.236:6543/tests/view/58dd5beb6e23db2fa8080e92

LTC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 2977 W: 1390 L: 1255 D: 332
http://35.161.250.236:6543/tests/view/58dd96eb6e23db2fa8080e98