### PR TITLE
Fix failed assertion in three-check chess

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1754,7 +1754,9 @@ bool Position::see_ge(Move m, Value v) const {
 #endif
 
 #ifdef THREECHECK
-  if (is_three_check() && gives_check(m))
+  if (   is_three_check()
+      && (   (color_of(moved_piece(m)) == sideToMove && gives_check(m))
+          || (st->checkSquares[type_of(moved_piece(m))] & to_sq(m))))
       return true;
 #endif
 


### PR DESCRIPTION
This works around the failed assertion in `gives_check` by directly calling the relevant code inside `see_ge.` This ensures that there is no functional change. A simplification is still desired, but at least the code is ensured to work.