### PR TITLE
Introduce new pawn evaluation term for horde chess

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -267,6 +267,10 @@ namespace {
   // in front of the king and no enemy pawn on the horizon.
   const Value MaxSafetyBonus = V(258);
 
+#ifdef HORDE
+  const Score ImbalancedHorde = S(30, 30);
+#endif
+
   #undef S
   #undef V
 
@@ -295,6 +299,18 @@ namespace {
     e->pawnAttacks[Us]   = shift<Right>(ourPawns) | shift<Left>(ourPawns);
     e->pawnsOnSquares[Us][BLACK] = popcount(ourPawns & DarkSquares);
     e->pawnsOnSquares[Us][WHITE] = pos.count<PAWN>(Us) - e->pawnsOnSquares[Us][BLACK];
+
+#ifdef HORDE
+    if (pos.is_horde() && pos.is_horde_color(Us))
+    {
+        int l = 0, m = 0, r = popcount(ourPawns & FileBB[FILE_A]);
+        for (File f1 = FILE_A; f1 <= FILE_H; ++f1)
+        {
+            l = m; m = r; r = f1 < FILE_H ? popcount(ourPawns & FileBB[f1 + 1]) : 0;
+            score -= ImbalancedHorde * m / ((l + 1) * (r + 1));
+        }
+    }
+#endif
 
     // Loop through all pawns of the current color and score each pawn
     while ((s = *pl++) != SQ_NONE)


### PR DESCRIPTION
Add a penalty for pawns in the horde with only few neighbors, since they lack support for advancing.

STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 2569 W: 1336 L: 1198 D: 35
http://35.161.250.236:6543/tests/view/58e16b9b6e23db2fa8080f3d

LTC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 6121 W: 3118 L: 2928 D: 75
http://35.161.250.236:6543/tests/view/58e17cc46e23db2fa8080f4e