### PR TITLE
Fix material hash for crazyhouse

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1355,7 +1355,10 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // Move the piece. The tricky Chess960 castling is handled earlier
 #ifdef CRAZYHOUSE
   if (type_of(m) == DROP)
+  {
       drop_piece(pc, to);
+      st->materialKey ^= Zobrist::psq[pc][pieceCount[pc]-1];
+  }
   else
 #endif
   if (type_of(m) != CASTLING)


### PR DESCRIPTION
When a piece is dropped, we have to update the material hash.

I verified that this fixes the material hash by adding the material hash to the debug output `d`. When comparing identical positions that were reached with and without drops, respectively, the material hashes differ when using current master, but are the same after the fix. Sample positions that can be used for verification:
```
position startpos moves e2e4
position fen rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKBNR[P] w KQkq - 0 1 moves P@e4
```
```
position startpos moves g1f3
position fen rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKB1R[N] w KQkq - 0 1 moves N@f3
```

Bugfix tested with simplification bounds:
STC
LLR: 2.97 (-2.94,2.94) [-10.00,5.00]
Total: 12721 W: 6111 L: 6136 D: 474
http://35.161.250.236:6543/tests/view/58e299fe6e23db2fa8080fa2

LTC
LLR: 2.99 (-2.94,2.94) [-10.00,5.00]
Total: 11874 W: 5660 L: 5679 D: 535
http://35.161.250.236:6543/tests/view/58e2abff6e23db2fa8080fa6