### PR TITLE
Tweak pruning for losers chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1150,6 +1150,9 @@ moves_loop: // When in check search starts from here
 #ifdef ANTI
               && (!pos.is_anti() || !(pos.attackers_to(to_sq(move)) & pos.pieces(~pos.side_to_move())))
 #endif
+#ifdef LOSERS
+              && (!pos.is_losers() || !(pos.attackers_to(to_sq(move)) & pos.pieces(~pos.side_to_move())))
+#endif
 #ifdef HORDE
               && (pos.is_horde() || !pos.advanced_pawn_push(move) || pos.non_pawn_material() >= 5000)
 #else


### PR DESCRIPTION
Less pruning for moves to attacked squares in losers chess.

STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 950 W: 477 L: 371 D: 102
http://35.161.250.236:6543/tests/view/58e515ac6e23db2fa8080fc2

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 816 W: 405 L: 303 D: 108
http://35.161.250.236:6543/tests/view/58e51ff86e23db2fa8080fc5