### PR TITLE
IID at lower depths for crazyhouse

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1027,7 +1027,11 @@ namespace {
     }
 
     // Step 10. Internal iterative deepening (skipped when in check)
+#ifdef CRAZYHOUSE
+    if (    depth >= (pos.is_house() ? 4 : 6) * ONE_PLY
+#else
     if (    depth >= 6 * ONE_PLY
+#endif
         && !ttMove
         && (PvNode || ss->staticEval + 256 >= beta))
     {


### PR DESCRIPTION
The branching factor is way higher in crazyhouse, so internal iterative deepening can be beneficial even at low depths.

STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 5024 W: 2486 L: 2315 D: 223
http://35.161.250.236:6543/tests/view/58e7ed996e23db2fa8080ff2

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 18804 W: 9076 L: 8709 D: 1019
http://35.161.250.236:6543/tests/view/58e80d4c6e23db2fa8080fff