### PR TITLE
Additional term for king danger in atomic chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -546,6 +546,9 @@ namespace {
   const int RookCheck         = 688;
   const int BishopCheck       = 588;
   const int KnightCheck       = 924;
+#ifdef ATOMIC
+  const int IndirectKingAttack = 1000;
+#endif
 
   // Threshold for lazy evaluation
   const Value LazyThreshold = Value(1500);
@@ -879,7 +882,10 @@ namespace {
 
 #ifdef ATOMIC
         if (pos.is_atomic())
+        {
+            kingDanger += IndirectKingAttack * popcount(pos.attacks_from<KING>(pos.square<KING>(Us)) & pos.pieces(Us) & ei.attackedBy[Them][ALL_PIECES]);
             score -= make_score(100, 100) * popcount(ei.attackedBy[Us][KING] & pos.pieces());
+        }
 #endif
         // Transform the kingDanger units into a Score, and substract it from the evaluation
         if (kingDanger > 0)


### PR DESCRIPTION
Increase king danger when there are indirect king attacks.

STC (failed yellow)
LLR: -2.95 (-2.94,2.94) [0.00,10.00]
Total: 7924 W: 2564 L: 2540 D: 2820
http://35.161.250.236:6543/tests/view/58fa0de16e23db04ee81d211

LTC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 3199 W: 995 L: 884 D: 1320
http://35.161.250.236:6543/tests/view/58fa85836e23db04ee81d217