### PR TITLE
Tweak king attack weights for crazyhouse

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -517,7 +517,7 @@ namespace {
     { 0, 0, 78, 56, 45, 11 },
 #endif
 #ifdef CRAZYHOUSE
-    { 0, 0, 78, 56, 45, 11 },
+    { 0, 0, 112, 84, 61, 2 },
 #endif
 #ifdef HORDE
     { 0, 0, 78, 56, 45, 11 },

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -508,7 +508,36 @@ namespace {
   #undef V
 
   // KingAttackWeights[PieceType] contains king attack weights by piece type
-  const int KingAttackWeights[PIECE_TYPE_NB] = { 0, 0, 78, 56, 45, 11 };
+  const int KingAttackWeights[VARIANT_NB][PIECE_TYPE_NB] = {
+    { 0, 0, 78, 56, 45, 11 },
+#ifdef ANTI
+    {},
+#endif
+#ifdef ATOMIC
+    { 0, 0, 78, 56, 45, 11 },
+#endif
+#ifdef CRAZYHOUSE
+    { 0, 0, 78, 56, 45, 11 },
+#endif
+#ifdef HORDE
+    { 0, 0, 78, 56, 45, 11 },
+#endif
+#ifdef KOTH
+    { 0, 0, 78, 56, 45, 11 },
+#endif
+#ifdef LOSERS
+    { 0, 0, 78, 56, 45, 11 },
+#endif
+#ifdef RACE
+    {},
+#endif
+#ifdef RELAY
+    { 0, 0, 78, 56, 45, 11 },
+#endif
+#ifdef THREECHECK
+    { 0, 0, 78, 56, 45, 11 },
+#endif
+  };
 
   const int KingSafetyParams[VARIANT_NB][8] = {
     {   807,  101,  235,  134, -717, -357,   -5,    0 },
@@ -645,7 +674,7 @@ namespace {
         if (b & ei.kingRing[Them])
         {
             ei.kingAttackersCount[Us]++;
-            ei.kingAttackersWeight[Us] += KingAttackWeights[Pt];
+            ei.kingAttackersWeight[Us] += KingAttackWeights[pos.variant()][Pt];
             ei.kingAdjacentZoneAttacksCount[Us] += popcount(b & ei.attackedBy[Them][KING]);
         }
 


### PR DESCRIPTION
STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 5781 W: 2887 L: 2704 D: 190
http://35.161.250.236:6543/tests/view/58fb4af76e23db04ee81d219

LTC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 3445 W: 1732 L: 1583 D: 130
http://35.161.250.236:6543/tests/view/58fc96fd6e23db04ee81d22d