### PR TITLE
Penalty for doubled pawns in horde chess

### DIFF
--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -550,7 +550,11 @@ namespace {
         if (connected)
             score += Connected[pos.variant()][opposed][!!phalanx][more_than_one(supported)][relative_rank(Us, s)];
 
+#ifdef HORDE
+        if (doubled && (!supported || pos.is_horde()))
+#else
         if (doubled && !supported)
+#endif
             score -= Doubled[pos.variant()];
 
         if (lever)


### PR DESCRIPTION
Apply doubled pawn penalty also to supported doubled pawns.

STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 1477 W: 791 L: 668 D: 18
http://35.161.250.236:6543/tests/view/590093476e23db04ee81d270

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 892 W: 498 L: 384 D: 10
http://35.161.250.236:6543/tests/view/5900ac846e23db04ee81d274