### PR TITLE
Update AUTHORS file with Multi Variant Stockfish contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,34 +4,41 @@ Tord Romstad
 Marco Costalba (mcostalba)
 Joona Kiiski (zamar)
 Gary Linscott (glinscott)
+Daniel Dugovic (ddugovic)
+Fabian Fichter (ianfab)
 Lucas Braesch (lucasart)
 Bill Henry (VoyagerOne)
-mstembera
+Niklas Fiekas (niklasf)
+Michael Stembera (mstembera, Fisherman)
+Joost VandeVondele (Joost Vandevondele)
 Stéphane Nicolet (Stephane Nicolet, snicolet)
 Stefan Geschwentner
 Alain SAVARD (Rocky640)
 Jörg Oster (Joerg Oster, joergoster)
 Reuven Peleg
-Chris Caino (Chris Cain, ceebo)
+Chris Cain (Chris Caino, ceebo)
+Stefano Cardanobile (Stefano80)
+Lakin Wecker
 Jean-Francois Romang
 homoSapiensSapiens
 Leonid Pechenik
-Stefano Cardanobile (Stefano80)
 Arjun Temurnikar
 Uri Blass (uriblass)
-jundery
-Ajith (ajithcj)
 hxim
-Ralph Stößer (Ralph Stoesser)
-Guenther Demetz
-Jonathan Calovski (Mysseno)
-Tom Vijlbrief
-mbootsector
-Daylen Yang
+jundery
 ElbertoOne
-Henri Wiechers
+Ajith (ajithcj)
+Jonathan Calovski (Mysseno)
+Ralph Stößer (Ralph Stoesser)
+mbootsector
+Guenther Demetz
+Tom Vijlbrief
 loco-loco
-Joost VandeVondele (Joost Vandevondele)
+sf-x
+Daylen Yang
+Henri Wiechers
+Aram Tumanian
+Isaac Levy
 Ronald de Man (syzygy)
 DU-jdto
 David Zar
@@ -39,33 +46,45 @@ Eelco de Groot
 Jerry Donald
 NicklasPersson
 Ryan Schmitt
+ThyChief
+erbsenzaehler
+pb00068
 Alexander Kure
+Andrew Grant
 Dan Schmidt
 H. Felix Wittmann
+Ivan Ivec (IIvec)
 Jacques
 Joseph R. Prostko
 Justin Blanchard
 Linus Arver
 Luca Brivio
 Lyudmil Antonov
+Miroslav Fontán
 Rodrigo Exterckötter Tjäder
 Ron Britvich
 RyanTaker
 Vince Negri
-erbsenzaehler
+atumanian
+gamander
 Joseph Hellis (jhellis3)
+Pasquale Pigazzini (ppigazzini)
 shane31
-Andrew Grant
+torfranz
+user
+Andrey Neporada
 Andy Duplain
 Auguste Pop
 Balint Pfliegel
 Dariusz Orzechowski
 DiscanX
 Ernesto Gatti
+Fabian Beuke
+FauziAkram
 Gregor Cramer
+GuardianRM
 Hiraoka Takuya (HiraokaTakuya)
 Hongzhi Cheng
-IIvec
 Kelly Wilson
 Ken T Takusagawa
 Kojirion
@@ -73,26 +92,26 @@ Krgp
 Matt Sullivan
 Matthew Lai
 Matthew Sullivan
+Michael Byrne
 Michel Van den Bergh
-Niklas Fiekas
+Mira
 Oskar Werkelin Ahlin
 Pablo Vazquez
 Pascal Romaret
 Raminder Singh
 Richard Lloyd
 Ryan Takker
+Sergei Antonov
 Thanar2
 absimaldata
-atumanian
+alwey
 braich
 fanon
-gamander
 gguliash
+goodkov
 kinderchocolate
 pellanda
-ppigazzini
 renouve
-sf-x
 thaspel
+theo77186
 unknown
-


### PR DESCRIPTION
Generated with 'git shortlog -sn | cut -c8-', which sorts by commits,
manually ordered the first four authors, merged duplicates.
Also fixed name/alias (Chris Cain) according to
https://groups.google.com/d/msg/fishcooking/1FdriZHxnto/VF8Vy7HOBwAJ