### PR TITLE
Disable the 50 move rule in Crazyhouse

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1927,6 +1927,9 @@ bool Position::see_ge(Move m, Value v) const {
 
 bool Position::is_draw(int ply) const {
 
+#ifdef CRAZYHOUSE
+  if (is_house()) {} else
+#endif
   if (st->rule50 > 99 && (!checkers() || MoveList<LEGAL>(*this).size()))
       return true;
 


### PR DESCRIPTION
Lichess disables the 50 move rule for Crazyhouse (which makes sense). I don't expect this to have any impact in real games, but let's disable it anyway, too.

Bench unchanged (all = 36138863).

/cc @programfox, @rpdelaney, @isaacl