### PR TITLE
Tweak evaluation parameters for racing kings

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -433,8 +433,8 @@ namespace {
 #ifdef RACE
   // Bonus for distance of king from 8th rank
   const Score KingRaceBonus[RANK_NB] = {
-    S(14216, 14428), S(5931, 5364), S(4372, 3800), S(2678, 2467),
-    S( 1577,  1515), S( 960,  914), S( 518,  480), S(   0,    0)
+    S(14282, 14493), S(6369, 5378), S(4224, 3557), S(2633, 2219),
+    S( 1614,  1456), S( 975,  885), S( 528,  502), S(   0,    0)
   };
 #endif
 

--- a/src/types.h
+++ b/src/types.h
@@ -343,10 +343,10 @@ enum Value : int {
   QueenValueMgLosers  = -122,  QueenValueEgLosers  = -213,
 #endif
 #ifdef RACE
-  KnightValueMgRace = 789,   KnightValueEgRace = 887,
-  BishopValueMgRace = 1053,  BishopValueEgRace = 1115,
-  RookValueMgRace   = 1300,  RookValueEgRace   = 1824,
-  QueenValueMgRace  = 1848,  QueenValueEgRace  = 2141,
+  KnightValueMgRace = 777,   KnightValueEgRace = 881,
+  BishopValueMgRace = 1025,  BishopValueEgRace = 1070,
+  RookValueMgRace   = 1272,  RookValueEgRace   = 1847,
+  QueenValueMgRace  = 1674,  QueenValueEgRace  = 2280,
 #endif
 #ifdef THREECHECK
   PawnValueMgThreeCheck   = 119,   PawnValueEgThreeCheck   = 205,


### PR DESCRIPTION
STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 2118 W: 604 L: 511 D: 1003
http://35.161.250.236:6543/tests/view/5930f5226e23db10d1b733ec

LTC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 5018 W: 1345 L: 1221 D: 2452
http://35.161.250.236:6543/tests/view/5930f54a6e23db10d1b733ef