### PR TITLE
Partition quiet moves in giveaway chess

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -177,6 +177,15 @@ void MovePicker::score<QUIETS>() {
   Color c = pos.side_to_move();
 
   for (auto& m : *this)
+#ifdef ANTI
+      if (pos.is_anti() && (pos.attackers_to(to_sq(m)) & pos.pieces(~c)))
+          m.value =  cmh[pos.moved_piece(m)][to_sq(m)]
+                  + fmh[pos.moved_piece(m)][to_sq(m)]
+                  + fm2[pos.moved_piece(m)][to_sq(m)]
+                  + history[c][from_to(m)]
+                  + (1 << 28);
+          else
+#endif
       m.value =  cmh[pos.moved_piece(m)][to_sq(m)]
                + fmh[pos.moved_piece(m)][to_sq(m)]
                + fm2[pos.moved_piece(m)][to_sq(m)]


### PR DESCRIPTION
Search those moves first that force the opponent to capture a piece.

STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 2601 W: 981 L: 867 D: 753
http://35.161.250.236:6543/tests/view/594f8bf46e23db117767f4fe

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 11580 W: 3805 L: 3585 D: 4190
http://35.161.250.236:6543/tests/view/594fda2f6e23db117767f509