### PR TITLE
Simplify move ordering of captures for giveaway chess

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -132,12 +132,6 @@ void MovePicker::score() {
   for (auto& m : *this)
       if (Type == CAPTURES)
       {
-#ifdef ANTI
-          if (pos.is_anti())
-              m.value = PieceValue[pos.variant()][MG][pos.piece_on(to_sq(m))]
-                      - Value(50 * relative_rank(pos.side_to_move(), to_sq(m)));
-          else
-#endif
 #ifdef ATOMIC
           if (pos.is_atomic())
               m.value = pos.see<ATOMIC_VARIANT>(m)


### PR DESCRIPTION
STC
LLR: 2.95 (-2.94,2.94) [-10.00,5.00]
Total: 1420 W: 512 L: 469 D: 439
http://35.161.250.236:6543/tests/view/59a0a45d6e23db60dc2b26a8

LTC
LLR: 2.99 (-2.94,2.94) [-10.00,5.00]
Total: 2721 W: 893 L: 859 D: 969
http://35.161.250.236:6543/tests/view/59a1252d6e23db60dc2b26b1