### PR TITLE
Simplify capture scoring for atomic chess

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -134,8 +134,7 @@ void MovePicker::score() {
       {
 #ifdef ATOMIC
           if (pos.is_atomic())
-              m.value = pos.see<ATOMIC_VARIANT>(m)
-                      - Value(200 * relative_rank(pos.side_to_move(), to_sq(m)));
+              m.value = pos.see<ATOMIC_VARIANT>(m);
           else
 #endif
 #ifdef CRAZYHOUSE


### PR DESCRIPTION
STC
LLR: 2.96 (-2.94,2.94) [-10.00,5.00]
Total: 5637 W: 1764 L: 1749 D: 2124
http://35.161.250.236:6543/tests/view/59b312886e23db64939d679c

LTC
LLR: 2.98 (-2.94,2.94) [-10.00,5.00]
Total: 1963 W: 592 L: 555 D: 816
http://35.161.250.236:6543/tests/view/59b39a5f6e23db64939d67b7