### PR TITLE
Limit king danger penalty in three-check chess (fix #406)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -984,6 +984,10 @@ namespace {
             if (pos.is_house() && v > QueenValueMg)
                 v = QueenValueMg;
 #endif
+#ifdef THREECHECK
+            if (pos.is_three_check() && v > QueenValueMg)
+                v = QueenValueMg;
+#endif
             score -= make_score(v, kingDanger / 16 + KDP[6] * v / 256);
         }
     }


### PR DESCRIPTION
Ensure that evaluations are within bounds of VALUE_INFINITE.

STC
LLR: 2.95 (-2.94,2.94) [-10.00,5.00]
Total: 4412 W: 2017 L: 1986 D: 409
http://35.161.250.236:6543/tests/view/59b55bac6e23db64939d67cd

LTC
LLR: 2.98 (-2.94,2.94) [-10.00,5.00]
Total: 1864 W: 855 L: 806 D: 203
http://35.161.250.236:6543/tests/view/59b58fbd6e23db64939d67d1