### PR TITLE
Tweak NMP verification search for giveaway chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -967,6 +967,10 @@ namespace {
 
         // Null move dynamic reduction based on depth and value
         Depth R = ((823 + 67 * depth / ONE_PLY) / 256 + std::min((eval - beta) / PawnValueMg, 3)) * ONE_PLY;
+#ifdef ANTI
+        if (pos.is_anti())
+            R = ((823 + 67 * depth / ONE_PLY) / 256 + std::min((eval - beta) / (2 * PawnValueMg), 3)) * ONE_PLY;
+#endif
 
         ss->currentMove = MOVE_NULL;
         ss->contHistory = &thisThread->contHistory[NO_PIECE][0];


### PR DESCRIPTION
Decrease evaluation-dependent reduction in NMP verification search.

STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 1363 W: 521 L: 425 D: 417
http://35.161.250.236:6543/tests/view/59d0bc2a6e23db0578f6ddb3

LTC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 2630 W: 917 L: 807 D: 906
http://35.161.250.236:6543/tests/view/59d108e06e23db0578f6ddc6