### PR TITLE
Asymmetric king safety evaluation for crazyhouse

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -987,6 +987,8 @@ namespace {
 #endif
             int v = kingDanger * kingDanger / 4096;
 #ifdef CRAZYHOUSE
+            if (pos.is_house() && Us == pos.side_to_move())
+                v -= v / 10;
             if (pos.is_house() && v > QueenValueMg)
                 v = QueenValueMg;
 #endif

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -915,7 +915,11 @@ namespace {
     else
     {
         eval = ss->staticEval =
+#ifdef CRAZYHOUSE
+        (ss-1)->currentMove != MOVE_NULL || pos.is_house() ? evaluate(pos)
+#else
         (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
+#endif
                                          : -(ss-1)->staticEval + 2 * Eval::Tempo[pos.variant()];
 
         tte->save(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
@@ -1522,7 +1526,11 @@ moves_loop: // When in check search starts from here
         }
         else
             ss->staticEval = bestValue =
+#ifdef CRAZYHOUSE
+            (ss-1)->currentMove != MOVE_NULL || pos.is_house() ? evaluate(pos)
+#else
             (ss-1)->currentMove != MOVE_NULL ? evaluate(pos)
+#endif
                                              : -(ss-1)->staticEval + 2 * Eval::Tempo[pos.variant()];
 
         // Stand pat. Return immediately if static value is at least beta


### PR DESCRIPTION
This is just a first attempt that shows that the idea of an asymmetric evaluation can work in crazyhouse, and I think that more sophisticated (king safety) evaluation asymmetry terms could improve a lot over this. Similar ideas might work for other variants that depend a lot on initiative, such as three-check or giveaway chess.

STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 9099 W: 4491 L: 4261 D: 347

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 12180 W: 5956 L: 5683 D: 541