### PR TITLE
Make crazyhouse FEN parsing more robust

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -264,23 +264,19 @@ Position& Position::set(const string& fenStr, bool isChess960, Variant v, StateI
           promotedPieces |= sq - Square(1);
       // Stop before pieces in hand
       else if (is_house() && token == '[')
-          break;
-#endif
-  }
-
-#ifdef CRAZYHOUSE
-  // Pieces in hand
-  if (is_house())
-  {
-      while ((ss >> token) && !isspace(token))
       {
-          if (token == ']')
-              continue;
-          else if ((idx = PieceToChar.find(token)) != string::npos)
-              add_to_hand(color_of(Piece(idx)), type_of(Piece(idx)));
+          // Pieces in hand
+          while ((ss >> token) && !isspace(token))
+          {
+              if (token == ']')
+                  continue;
+              else if ((idx = PieceToChar.find(token)) != string::npos)
+                  add_to_hand(color_of(Piece(idx)), type_of(Piece(idx)));
+          }
+          break;
       }
-  }
 #endif
+  }
 
   // 2. Active color
   ss >> token;


### PR DESCRIPTION
Allow skipping the brackets to support standard chess FENs and simplify the code a bit. No functional change for valid input.