### PR TITLE
Fix from_to for piece drops in crazyhouse (fixes #432)

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -635,7 +635,7 @@ inline Square to_sq(Move m) {
 inline int from_to(Move m) {
 #ifdef CRAZYHOUSE
   if (type_of(m) == DROP)
-      return (m & 0xFFF) + 0x1000;
+      return (m & 0x3F) + 0x1000;
 #endif
  return m & 0xFFF;
 }


### PR DESCRIPTION
Since the bits of the destination square are used to encode the dropped piece
(Edit: not its type), we have to exclude these bits when determining
from_to for piece drops in order to avoid exceeding the limits, i.e.,
causing out of bound array accesses.

The failed assertion occured when the index for the mainHistory exceeded
the limits and actually changed a value in the adjacent captureHistory,
which has lower maximum values.