### PR TITLE
Double size of move list for horde chess

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -102,7 +102,7 @@ const bool Is64Bit = false;
 typedef uint64_t Key;
 typedef uint64_t Bitboard;
 
-#ifdef CRAZYHOUSE
+#if defined(CRAZYHOUSE) || defined(HORDE)
 const int MAX_MOVES = 512;
 #else
 const int MAX_MOVES = 256;


### PR DESCRIPTION
There seem to be positions in horde chess where there are more than 256 moves,
e.g., knQQQQQQ/pn5Q/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/QQQQQQQQ w - - 0 1. To deal with that,
increase the maximum number of moves to 512.

I have not checked whether the mentioned position is entirely legal (i.e., reachable from the starting position), but even if not, it shows that legal positions with more than 256 legal moves should exist.