### PR TITLE
Fix SEE for quiet moves in extinction chess

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1833,7 +1833,7 @@ bool Position::see_ge(Move m, Value threshold) const {
 #endif
 #ifdef EXTINCTION
   // Is it a winning capture?
-  if (is_extinction() && !more_than_one(pieces(color_of(piece_on(to)), type_of(piece_on(to)))))
+  if (is_extinction() && piece_on(to) != NO_PIECE && !more_than_one(pieces(color_of(piece_on(to)), type_of(piece_on(to)))))
       return true;
 #endif
   Value balance; // Values of the pieces taken by us minus opponent's ones


### PR DESCRIPTION
Fix a failed assertion due to color_of(NO_PIECE).

STC
LLR: 2.98 (-2.94,2.94) [-10.00,5.00]
Total: 863 W: 375 L: 323 D: 165
http://35.161.250.236:6543/tests/view/5a0234156e23db2fc44adbe7

LTC (failed)
LLR: -2.99 (-2.94,2.94) [-10.00,5.00]
Total: 4759 W: 1952 L: 2045 D: 762
http://35.161.250.236:6543/tests/view/5a0235ba6e23db2fc44adbea

This fix did not pass LTC, but the Elo loss seems to be moderate, and considering that a previous SEE change (that introduced this bug) was a huge Elo improvement, I think fixing this would be helpful for trying to further improve SEE. Let me know if you would like to see further tests or the like.