### PR TITLE
Tweak piece values for grid chess

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -353,11 +353,11 @@ enum Value : int {
   KingValueMgExtinction   = 919,   KingValueEgExtinction   = 1093,
 #endif
 #ifdef GRID
-  PawnValueMgGrid   = 171,   PawnValueEgGrid   = 240,
-  KnightValueMgGrid = 764,   KnightValueEgGrid = 848,
-  BishopValueMgGrid = 826,   BishopValueEgGrid = 891,
-  RookValueMgGrid   = 1282,  RookValueEgGrid   = 1373,
-  QueenValueMgGrid  = 2526,  QueenValueEgGrid  = 2646,
+  PawnValueMgGrid   = 51,    PawnValueEgGrid   = 72,
+  KnightValueMgGrid = 982,   KnightValueEgGrid = 900,
+  BishopValueMgGrid = 690,   BishopValueEgGrid = 781,
+  RookValueMgGrid   = 1018,  RookValueEgGrid   = 1094,
+  QueenValueMgGrid  = 2568,  QueenValueEgGrid  = 2354,
 #endif
 #ifdef HORDE
   PawnValueMgHorde   = 321,   PawnValueEgHorde   = 326,


### PR DESCRIPTION
STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 98 W: 77 L: 4 D: 17
http://35.161.250.236:6543/tests/view/5a0a97f26e23db617088d90d

LTC
LLR: 7.37 (-2.94,2.94) [0.00,10.00]
Total: 190 W: 147 L: 1 D: 42
http://35.161.250.236:6543/tests/view/5a0a99f86e23db617088d911

The most noticeable changes are the drastically reduced pawn values. Since pawns can not promote (without multiple captures), the values make sense to me. 