### PR TITLE
Build binary snapshots for Linux, OSX and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,3 +105,16 @@ script:
   #
   - if [[ "$DEPLOY" == "stockfish" ]]; then make clean && git apply ../deploy/old-gcc.patch && docker build --tag wheezy-for-sf -f ../deploy/wheezy.dockerfile ../deploy && docker run --volume "$PWD/..:/home/builder/Stockfish" --user $(id -u) wheezy-for-sf; fi
   - if [[ "$DEPLOY" == "stockfish-osx" ]]; then make clean && make build ARCH=x86-64 EXE=stockfish-osx-x86_64; fi
+
+deploy:
+  provider: releases
+  api_key:
+    secure: NnKCSB28jDimmkf4A8KNnve1ROnmBNHJSrZQV+c00uQ2ZFLreBU3D5rpF5MHBVjLhp5I3RYk6JHrnPUk+aobgU5+S1xZWMz9fjSlhhgYaMK5sByoMOUAVFJN+yzSHZDzhfHZ5fsEqqSO1ftGnUz59p4+xlOobPqt+KqUk3nIHFpBDbKxTEmYodp/pJCtiYrXV/1fLLsvlJnXmZ71LzgM94ExxEuZ+tO9WzK9GLdQNP/cWVtAi6wTcVhzNTBYEnM6191zpLMg3ovmGowkKYuqna0CA6GKfR/TvZnQcklyY6VuaCpvNmXM17KO/37C0ZrmehUyLLyvN+a+REgffqcPt84g96an+Q37zHkJGy8TauQjhotMYkKfYkkFJ071xxxNpRITdRK/WuczTusC7V7GT+vDiCoRKsdDx36ORQAldUbrGSjHXjdP75xU7YfuVxPB7GKeK2UuQWBukGWdN3WohoTtiorgIOvc3jnbbXNbVFijs7oN35YfJWu7CKcP9yIHyYyJY8GzHMgm6S1Ec5cmTNPys4cKtkxaoqdBg9B0fxNlP4Wupx21Tt3Jg+MnVwn2eBAADsPo8CXsA4Ykj5AD2Zo+/TeJziMjMv0YRFozYR4AcPcSJVq8XSI4PnmdxZzfgSUo9A0jXYU0gaqS7TpBjvQN0H8SE8a9eGIzH3BKL0A=
+  prerelease: false
+  file_glob: true
+  file:
+    - stockfish-*
+  skip_cleanup: true
+  on:
+    tags: true
+    repo: ddugovic/Stockfish

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,8 @@ script:
   #
   # Build snapshot
   #
-  - if [[ "$DEPLOY" == "stockfish" ]]; then make clean && git apply ../deploy/old-gcc.patch && docker build --tag wheezy-for-sf -f ../deploy/wheezy.dockerfile ../deploy && docker run --volume "$PWD/..:/home/builder/Stockfish" --user $(id -u) wheezy-for-sf; fi
-  - if [[ "$DEPLOY" == "stockfish-osx" ]]; then make clean && make build ARCH=x86-64 EXE=stockfish-osx-x86_64; fi
+  - if [[ "${TRAVIS_PULL_REQUEST}" = "false" && "$DEPLOY" == "stockfish" ]]; then make clean && git apply ../deploy/old-gcc.patch && docker build --tag wheezy-for-sf -f ../deploy/wheezy.dockerfile ../deploy && docker run --volume "$PWD/..:/home/builder/Stockfish" --user $(id -u) wheezy-for-sf; fi
+  - if [[ "${TRAVIS_PULL_REQUEST}" = "false" && "$DEPLOY" == "stockfish-osx" ]]; then make clean && make build ARCH=x86-64 EXE=stockfish-osx-x86_64; fi
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,27 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-6', 'g++-6-multilib', 'g++-multilib', 'valgrind', 'expect']
+        artifacts:
+          bucket: variant-stockfish
+          s3_region: us-west-2
+          working_dir: src
+          paths:
+            - stockfish-x86_64
+            - stockfish-x86_64-modern
+            - stockfish-x86_64-bmi2
+          target_paths: ddugovic/${TRAVIS_BRANCH}
+          cache_control: public
+          key:
+            secure: Q+ep2DL+HlYe4jzf4hHRT/0d5oAvyL1DLW7jLhLpukZMaUuOR4MA3MeBiLUjG5cvCoprrTL0YFEdX4dlr7xEj8L/XGPHO4WEzPGThXiK3pTeRRz8V32+9oeqmLeTBAcVXtp6O5xKGna75isNDdDm9jpTBSA5iGQ/wvrXc+rS5RmhAVeVs/Un94fkOd+yWOkGsl1GWx7D9kwUsUaB7jzM34jM+WFhk26uJUQuFTa4VWe/j73uAiWDYiPmpveB2tYWMrD/xmEkrQ8apzhiPkaMBigjLgyYlaEDugoQ9tZYML+/98PiGB1EFiYnydNZpFNtO2jfKN9VPt6Poun+Fhj8jkS07hSBYtId6d1PvbQCjCR6eOak8q3phGraXlly41sq+O9C+RZ64MdgBT0OHzCrE63VZUzB9hZEbeHNH35ZyL1ytMb5SWNzgqb3VkWugITIl8nel+mbSjWgV4fzHOpC4Je7uOiywRvMbdWwBoJ7PSJ72f9GQMJ2Ibc0gQ7+LwxeK7NSsYtd3FZdTfxEp/8a6imCdjuM8huCPXqQxxu8Qp6F3+FiCnJev8+zlNDJlZ9gYi/7Fcfg4QqlbX8kWLhDR4U2ecP/6i+qSZ0mMOM7eNSLbyO5eFZbbYz9UW9IQasrF0PYc94S/dkK+QOtH8BKeVYLgHnKLquX2nMy1lb+Ug0=
+          secret:
+            secure: OWJPxKbGK4xyIkHMqUE100hfXLd4QHAQXLaYj5PemcJxT9vbWurrWHCtkIqhikKMgw6ii12JrdGvOd/wT31ZMR3g1xxc5cu0/cRx1zyBNZkGEScVZE6R3Y1Y5Y812xFY98mdq84mGILsS+mlL0HUqv68331kxTnWHLc8h+59wSOviPUzDCmyAarMd+AfHLqEi4QqR5g377TXImKFhSzOvpQtSlK3LH1Kfyl1LlPlVhBGf7jNlECr7GTGy1y89ahMF4ZEYDQED4qD2IbA988FaaN7GYQWQZ9esZ9mVMco+CIfjk/0+3+6K99tqQYFU7MW4w7AVwCnQqMLZZHz7JlCAInRv99fx3G4QHwjaZbTbfNashHKC7qu1Wvvqsim2RSLb+RkEH/cUXT6PcUHL1K/muHypHDYHxyY7dj8M35rTXaDjYypl0hmGxWPLLoqH7jJRXQpW3Z6ho+4ThTAlQZ3qoBMW+Ses53v93clq6Hr9RaVWNHZ2mCnq/6LAHWz19TPVu3QyrP6nhO1XM1/t/zFsvjTe83/Rp/kRxOjUksUjQRpvlHW4OoxjerQQ8Gu+K+fW6hdryPFyO1hpkJpQ0vPOBRuK81HAIN9BRf9CREhdJ4rj1PvYocKk0FqZVaJIHUtW2jwcwtxAIPephLJJvLyhwa6yx0veeSXSQW0domzxnA=
       env:
         - COMPILER=g++-6
         - COMP=gcc
+        - DEPLOY=stockfish
+      sudo: required
+      services:
+        - docker
 
     - os: linux
       compiler: clang
@@ -35,10 +53,20 @@ matrix:
       env:
         - COMPILER=clang++ V='Apple LLVM 6.0' # Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
         - COMP=clang
-
-branches:
-  only:
-   - master
+        - DEPLOY=stockfish-osx
+      addons:
+        artifacts:
+          bucket: variant-stockfish
+          s3_region: us-west-2
+          working_dir: src
+          paths:
+            - stockfish-osx-x86_64
+          target_paths: ddugovic/${TRAVIS_BRANCH}
+          cache_control: public
+          key:
+            secure: Q+ep2DL+HlYe4jzf4hHRT/0d5oAvyL1DLW7jLhLpukZMaUuOR4MA3MeBiLUjG5cvCoprrTL0YFEdX4dlr7xEj8L/XGPHO4WEzPGThXiK3pTeRRz8V32+9oeqmLeTBAcVXtp6O5xKGna75isNDdDm9jpTBSA5iGQ/wvrXc+rS5RmhAVeVs/Un94fkOd+yWOkGsl1GWx7D9kwUsUaB7jzM34jM+WFhk26uJUQuFTa4VWe/j73uAiWDYiPmpveB2tYWMrD/xmEkrQ8apzhiPkaMBigjLgyYlaEDugoQ9tZYML+/98PiGB1EFiYnydNZpFNtO2jfKN9VPt6Poun+Fhj8jkS07hSBYtId6d1PvbQCjCR6eOak8q3phGraXlly41sq+O9C+RZ64MdgBT0OHzCrE63VZUzB9hZEbeHNH35ZyL1ytMb5SWNzgqb3VkWugITIl8nel+mbSjWgV4fzHOpC4Je7uOiywRvMbdWwBoJ7PSJ72f9GQMJ2Ibc0gQ7+LwxeK7NSsYtd3FZdTfxEp/8a6imCdjuM8huCPXqQxxu8Qp6F3+FiCnJev8+zlNDJlZ9gYi/7Fcfg4QqlbX8kWLhDR4U2ecP/6i+qSZ0mMOM7eNSLbyO5eFZbbYz9UW9IQasrF0PYc94S/dkK+QOtH8BKeVYLgHnKLquX2nMy1lb+Ug0=
+          secret:
+            secure: OWJPxKbGK4xyIkHMqUE100hfXLd4QHAQXLaYj5PemcJxT9vbWurrWHCtkIqhikKMgw6ii12JrdGvOd/wT31ZMR3g1xxc5cu0/cRx1zyBNZkGEScVZE6R3Y1Y5Y812xFY98mdq84mGILsS+mlL0HUqv68331kxTnWHLc8h+59wSOviPUzDCmyAarMd+AfHLqEi4QqR5g377TXImKFhSzOvpQtSlK3LH1Kfyl1LlPlVhBGf7jNlECr7GTGy1y89ahMF4ZEYDQED4qD2IbA988FaaN7GYQWQZ9esZ9mVMco+CIfjk/0+3+6K99tqQYFU7MW4w7AVwCnQqMLZZHz7JlCAInRv99fx3G4QHwjaZbTbfNashHKC7qu1Wvvqsim2RSLb+RkEH/cUXT6PcUHL1K/muHypHDYHxyY7dj8M35rTXaDjYypl0hmGxWPLLoqH7jJRXQpW3Z6ho+4ThTAlQZ3qoBMW+Ses53v93clq6Hr9RaVWNHZ2mCnq/6LAHWz19TPVu3QyrP6nhO1XM1/t/zFsvjTe83/Rp/kRxOjUksUjQRpvlHW4OoxjerQQ8Gu+K+fW6hdryPFyO1hpkJpQ0vPOBRuK81HAIN9BRf9CREhdJ4rj1PvYocKk0FqZVaJIHUtW2jwcwtxAIPephLJJvLyhwa6yx0veeSXSQW0domzxnA=
 
 before_script:
   - cd src
@@ -71,3 +99,9 @@ script:
   # Use g++-6 as a proxy for having sanitizers, might need revision as they become available for more recent versions of clang/gcc
   - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make -j2 ARCH=x86-64 sanitize=undefined optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-undefined; fi
   - if [[ "$COMPILER" == "g++-6" ]]; then make clean && make -j2 ARCH=x86-64 sanitize=thread    optimize=no debug=yes build > /dev/null && ../tests/instrumented.sh --sanitizer-thread; fi
+
+  #
+  # Build snapshot
+  #
+  - if [[ "$DEPLOY" == "stockfish" ]]; then make clean && git apply ../deploy/old-gcc.patch && docker build --tag wheezy-for-sf -f ../deploy/wheezy.dockerfile ../deploy && docker run --volume "$PWD/..:/home/builder/Stockfish" --user $(id -u) wheezy-for-sf; fi
+  - if [[ "$DEPLOY" == "stockfish-osx" ]]; then make clean && make build ARCH=x86-64 EXE=stockfish-osx-x86_64; fi

--- a/deploy/appveyor.yml
+++ b/deploy/appveyor.yml
@@ -21,13 +21,23 @@ artifacts:
   - path: '*\stockfish-windows-*'
 
 deploy:
-  provider: S3
-  access_key_id:
-    secure: 1BWB8sb0ecF9242HMlKH54uFCn9GtjhxeaysqbVVDG4=
-  secret_access_key:
-    secure: l+Z1nugPzeV5fviFeckmfjjpvz7vfoALSMDt40Se77enlblgsr0/+/MrHQ+PMx/a
-  bucket: variant-stockfish
-  region: us-west-2
-  set_public: true
-  folder: ddugovic
-  artifact: /stockfish-windows-.*/
+  - provider: S3
+    access_key_id:
+      secure: 1BWB8sb0ecF9242HMlKH54uFCn9GtjhxeaysqbVVDG4=
+    secret_access_key:
+      secure: l+Z1nugPzeV5fviFeckmfjjpvz7vfoALSMDt40Se77enlblgsr0/+/MrHQ+PMx/a
+    bucket: variant-stockfish
+    region: us-west-2
+    set_public: true
+    folder: ddugovic
+    artifact: /stockfish-windows-.*/
+  - provider: GitHub
+    release: $(APPVEYOR_REPO_TAG_NAME)
+    description: 'Multi-variant Stockfish binaries'
+    auth_token:
+      secure: HM1uS+Vhume4hO4gY5Ev8XU8rurfeviKBNbfu3xOrl3zWnKcsdAzkNA2JExElSAM
+    artifact: /stockfish-windows-.*/
+    draft: false
+    prerelease: false
+    on:
+      appveyor_repo_tag: true

--- a/deploy/appveyor.yml
+++ b/deploy/appveyor.yml
@@ -1,0 +1,33 @@
+os: Visual Studio 2013
+
+clone_folder: C:\projects\Stockfish
+shallow_clone: true
+clone_depth: 1
+
+platform: x64
+
+cache:
+  - x86_64-4.9.2-release-posix-seh-rt_v4-rev2.7z
+
+install:
+  - cinst wget
+  - wget --no-clobber "http://sourceforge.net/projects/mingw-w64/files/Toolchains targetting Win64/Personal Builds/mingw-builds/4.9.2/threads-posix/seh/x86_64-4.9.2-release-posix-seh-rt_v4-rev2.7z"
+  - 7z x -oC:\MinGW\msys\1.0\ x86_64-4.9.2-release-posix-seh-rt_v4-rev2.7z > nul
+
+build_script:
+  - C:\MinGW\msys\1.0\bin\sh.exe -c "cd /c/projects/Stockfish/; /c/projects/Stockfish/deploy/msys.sh"
+
+artifacts:
+  - path: '*\stockfish-windows-*'
+
+deploy:
+  provider: S3
+  access_key_id:
+    secure: 1BWB8sb0ecF9242HMlKH54uFCn9GtjhxeaysqbVVDG4=
+  secret_access_key:
+    secure: l+Z1nugPzeV5fviFeckmfjjpvz7vfoALSMDt40Se77enlblgsr0/+/MrHQ+PMx/a
+  bucket: variant-stockfish
+  region: us-west-2
+  set_public: true
+  folder: ddugovic
+  artifact: /stockfish-windows-.*/

--- a/deploy/linux.sh
+++ b/deploy/linux.sh
@@ -1,0 +1,47 @@
+#!/bin/sh -e
+
+cd src
+
+echo
+echo "### Linker info"
+echo
+ldd --version || echo "no ldd"
+
+echo
+echo "### CPU capabilities"
+echo
+grep "^flags" /proc/cpuinfo || echo
+
+echo
+echo "### Running profile-build for x86-64 ..."
+echo
+make clean
+make profile-build ARCH=x86-64 EXE=stockfish-x86_64
+
+if [ -f /proc/cpuinfo ]; then
+    make clean
+    if grep "^flags" /proc/cpuinfo | grep -q popcnt ; then
+        echo
+        echo "### Running profile-build for x86-64-modern ..."
+        echo
+        make profile-build ARCH=x86-64-modern EXE=stockfish-x86_64-modern
+    else
+        echo
+        echo "### Running build for x86-64-modern ..."
+        echo
+        make build ARCH=x86-64-modern EXE=stockfish-x86_64-modern
+    fi
+
+    make clean
+    if grep "^flags" /proc/cpuinfo | grep popcnt | grep -q bmi2 ; then
+        echo
+        echo "### Running profile-build for x86-64-bmi2 ..."
+        echo
+        make profile-build ARCH=x86-64-bmi2 EXE=stockfish-x86_64-bmi2
+    else
+        echo
+        echo "### Running build for x86-64-bmi2 ..."
+        echo
+        make build ARCH=x86-64-bmi2 EXE=stockfish-x86_64-bmi2
+    fi
+fi

--- a/deploy/msys.sh
+++ b/deploy/msys.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+export PATH=.:/mingw64/bin:/usr/local/bin:/mingw/bin:/bin
+export
+mkdir "$APPVEYOR_REPO_BRANCH"
+
+cd src
+
+make clean
+make profile-build COMP=mingw ARCH=x86-64
+strip stockfish.exe
+mv stockfish.exe "../$APPVEYOR_REPO_BRANCH/stockfish-windows-x86_64.exe"
+
+make clean
+make profile-build COMP=mingw ARCH=x86-64-modern
+strip stockfish.exe
+mv stockfish.exe "../$APPVEYOR_REPO_BRANCH/stockfish-windows-x86_64-modern.exe"
+
+make clean
+make profile-build COMP=mingw ARCH=x86-64-bmi2
+strip stockfish.exe
+mv stockfish.exe "../$APPVEYOR_REPO_BRANCH/stockfish-windows-x86_64-bmi2.exe"
+
+cd ..

--- a/deploy/old-gcc.patch
+++ b/deploy/old-gcc.patch
@@ -1,0 +1,13 @@
+diff --git a/src/thread.h b/src/thread.h
+index 3aa5bb51..ac72d15d 100644
+--- a/src/thread.h
++++ b/src/thread.h
+@@ -84,7 +84,7 @@ public:
+ 
+ struct MainThread : public Thread {
+ 
+-  using Thread::Thread;
++  explicit MainThread(size_t n) : Thread(n) { }
+ 
+   void search() override;
+   void check_time();

--- a/deploy/wheezy.dockerfile
+++ b/deploy/wheezy.dockerfile
@@ -1,0 +1,7 @@
+FROM debian:wheezy
+RUN apt-get update && apt-get install -y make g++
+VOLUME /home/builder/Stockfish
+WORKDIR /home/builder/Stockfish
+RUN groupadd -r builder && useradd -r -g builder builder
+USER builder
+CMD ./deploy/linux.sh


### PR DESCRIPTION
This will build binary snapshots (profile-build) every time a new commit is pushed to the repository. The latest binaries will then be downloadable from Amazon S3. For example for the master branch:

* https://s3-us-west-2.amazonaws.com/variant-stockfish/ddugovic/master/stockfish-x86_64
* https://s3-us-west-2.amazonaws.com/variant-stockfish/ddugovic/master/stockfish-x86_64-modern
* https://s3-us-west-2.amazonaws.com/variant-stockfish/ddugovic/master/stockfish-x86_64-bmi2
* https://s3-us-west-2.amazonaws.com/variant-stockfish/ddugovic/master/stockfish-osx-x86_64
* https://s3-us-west-2.amazonaws.com/variant-stockfish/ddugovic/master/stockfish-windows-x86_64.exe
* https://s3-us-west-2.amazonaws.com/variant-stockfish/ddugovic/master/stockfish-windows-x86_64-modern.exe
* https://s3-us-west-2.amazonaws.com/variant-stockfish/ddugovic/master/stockfish-windows-x86_64-bmi2.exe

I made a seperate `appveyor.yml` to avoid future merge conflicts.

Unfortunately Travis CI supports only a single `.travis.yml`. I tried to keep changes minimal (or at least not restructure the file) for mergability.