### PR TITLE
Tweak pruning margins for grid chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,7 +83,7 @@ namespace {
   { 0, 570, 603, 554 },
 #endif
 #ifdef GRID
-  { 0, 570, 603, 554 },
+  { 0, 593, 601, 517 },
 #endif
 #ifdef HORDE
   { 0, 706, 625, 555 },
@@ -122,7 +122,7 @@ namespace {
   150,
 #endif
 #ifdef GRID
-  150,
+  181,
 #endif
 #ifdef HORDE
   151,
@@ -161,6 +161,9 @@ namespace {
 #ifdef EXTINCTION
   { 256, 200 },
 #endif
+#ifdef GRID
+  { 278, 168 },
+#endif
 #ifdef HORDE
   { 261, 162 },
 #endif
@@ -198,7 +201,7 @@ namespace {
   400,
 #endif
 #ifdef GRID
-  200,
+  222,
 #endif
 #ifdef HORDE
   153,


### PR DESCRIPTION
And introduce missing futility margin array entries.

STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 7810 W: 1406 L: 1280 D: 5124
http://35.161.250.236:6543/tests/view/5a0ca7356e23db617088d91b

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 3952 W: 669 L: 578 D: 2705
http://35.161.250.236:6543/tests/view/5a0cbbec6e23db617088d91e