### PR TITLE
Support displaced and slipped grid chess

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -259,15 +259,25 @@ ifneq ($(comp),mingw)
 endif
 
 ### 3.2.1 Debugging
-CXXFLAGS += -DANTI -DATOMIC -DBUGHOUSE -DCRAZYHOUSE -DEXTINCTION -DGRID -DHORDE -DKOTH -DLOOP -DLOSERS -DRACE -DSKILL -DSUICIDE -DTHREECHECK -DTWOKINGS -DTWOKINGSSYMMETRIC -DUSELONGESTPV
+CXXFLAGS += -DANTI -DATOMIC -DBUGHOUSE -DCRAZYHOUSE -DDISPLACEDGRID -DEXTINCTION -DGRID -DHORDE -DKOTH -DLOOP -DLOSERS -DRACE -DSKILL -DSLIPPEDGRID -DSUICIDE -DTHREECHECK -DTWOKINGS -DTWOKINGSSYMMETRIC -DUSELONGESTPV
 ifneq (,$(filter -DBUGHOUSE,$(CXXFLAGS)))
 ifeq (,$(filter -DCRAZYHOUSE,$(CXXFLAGS)))
 $(error Crazyhouse (-DCRAZYHOUSE) is required for subvariant bughouse chess)
 endif
 endif
+ifneq (,$(filter -DDISPLACEDGRID,$(CXXFLAGS)))
+ifeq (,$(filter -DGRID,$(CXXFLAGS)))
+$(error Grid (-GRID) is required for subvariant displaced grid)
+endif
+endif
 ifneq (,$(filter -DLOOP,$(CXXFLAGS)))
 ifeq (,$(filter -DCRAZYHOUSE,$(CXXFLAGS)))
 $(error Crazyhouse (-DCRAZYHOUSE) is required for subvariant loop chess)
+endif
+endif
+ifneq (,$(filter -DSLIPPEDGRID,$(CXXFLAGS)))
+ifeq (,$(filter -DGRID,$(CXXFLAGS)))
+$(error Grid (-GRID) is required for subvariant slipped grid)
 endif
 endif
 ifneq (,$(filter -DSUICIDE,$(CXXFLAGS)))

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -31,7 +31,7 @@ using namespace std;
 
 namespace {
 
-const vector<string> Defaults[VARIANT_NB] = {
+const vector<string> Defaults[SUBVARIANT_NB] = {
   {
   "setoption name UCI_Variant value chess",
   "setoption name UCI_Chess960 value false",
@@ -265,6 +265,93 @@ const vector<string> Defaults[VARIANT_NB] = {
     "rnbqk2r/ppppkppp/5n2/4p3/4P3/5N2/PPPPKPPP/RNBQK2R w KQkq - 4 4"
   },
 #endif
+#ifdef SUICIDE
+  {
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    "rn1qkbnr/p1pBpppp/8/8/8/4P3/PPPP1PbP/RNBQK1NR w - - 0 4",
+    "rnbqkbnr/p2p1ppp/8/2p1p3/2pP4/2N3P1/PP2PP1P/R1BQKBNR b - d3 0 5",
+    "rnb1kbn1/p4ppr/8/3q4/1p6/6PB/P3PP1P/R1B1K1NR b - - 1 11",
+    "r7/4rp1p/4p3/p1p5/P1P1P2P/8/2K1NPP1/7R w - - 11 26",
+    "8/8/1r6/p7/P2k4/8/2pp2K1/3k2K1 w - - 4 42",
+
+    // 2-man positions
+    "2K5/8/4r3/8/8/8/8/8 b - - 0 1", // win
+
+    // 3-man positions
+    "8/3nP3/8/8/8/8/7R/8 w - - 0 1", // e8B - win
+    "8/8/8/8/3K4/5K2/8/1r6 w - - 0 1", // draw
+
+    // 5-man positions
+    "8/pb4Pp/8/2p5/8/8/8/8 b - - 0 1", // Bc6 - draw
+    "k7/8/3PN3/p4K2/8/8/8/8 b - - 0 1", // loss
+
+    // 6-man positions
+    "8/3K4/2K5/3K1K2/8/8/3kk3/8 b - - 0 1", // draw
+
+    // Win by having no pieces left
+    "3q4/3k1pp1/7n/5p2/8/4r3/8/8 w - - 0 1",
+
+    // Stalemate
+    "1r6/5k2/8/p4b2/P1p5/8/8/8 w - - 0 1", // less pieces
+    "7b/7P/8/2p5/2P5/8/8/8 w - - 0 1", // equal number of pieces
+    "6bB/5pP1/5P2/8/8/8/8/8 w - - 0 1" // more pieces
+  },
+#endif
+#ifdef BUGHOUSE
+  {
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1",
+    "rnbqkb1r/ppp1pppp/5n2/3pP3/8/8/PPPP1PPP/RNBQKBNR[] w KQkq d6 4 3", // en passant
+    "r1bk3r/pppp1Bpp/2n5/4p1N1/4P3/3P4/PPP1p1PP/RNK4R[NQPBqb] b - - 23 12", // repetition detection
+    "r3k2r/pppb1ppp/4n3/2P1Q3/2p1n3/2Pb1N2/PP1NpPPP/R1BqR1K1[BP] w kq - 28 15",
+    "r1b1kb1r/p1p3pp/2pp4/8/4P3/2NR3P/PPP2P1P/5K1R[BBQNnqnppp] b kq - 39 20", // many pieces in hand
+    "r1b1r1k1/ppp1Pppp/8/3p4/3P2P1/PN6/2PBQP1P/q1q~1KB1R[NNbrnp] w - - 42 22", // promoted queen
+    "r3kb1r/1bpppppp/p1N2p2/2NPP3/2PP4/2N2Pb1/P3P1R1/R1Q2KBq[Pn] w kq - 54 28",
+    "7k/Q2P1pp1/2PPpn1p/3p1b2/3P4/P1n1P3/P1n1bPPP/R1B3KR[RRqbnp] w - - 48 25", // promotion
+
+    // Checkmate
+    "r1b2rk1/pppp1ppp/2P2b2/1N6/5N2/4P1K1/P1P4P/1Nrb1b1n~[NPPQQrp] w - - 64 33", // promoted knight
+    "1Rbk3r/p1pQ1ppp/2Bn3n/4p1b1/4Pn2/3p4/PbPP1PPP/3RK1R1[QPPn] b - - 45 23",
+
+    // Stalemate
+    "2R5/3Q2pk/2p1p3/1pP1P1Qp/1P3P1P/p1P1B3/P7/1R2K3[NRBNPBPRNPBN] b - - 98 55",
+  },
+#endif
+#ifdef DISPLACEDGRID
+  {
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  },
+#endif
+#ifdef LOOP
+  {
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1",
+    "rnbqkb1r/ppp1pppp/5n2/3pP3/8/8/PPPP1PPP/RNBQKBNR[] w KQkq d6 4 3", // en passant
+    "r1bk3r/pppp1Bpp/2n5/4p1N1/4P3/3P4/PPP1p1PP/RNK4R[NQPBqb] b - - 23 12", // repetition detection
+    "r3k2r/pppb1ppp/4n3/2P1Q3/2p1n3/2Pb1N2/PP1NpPPP/R1BqR1K1[BP] w kq - 28 15",
+    "r1b1kb1r/p1p3pp/2pp4/8/4P3/2NR3P/PPP2P1P/5K1R[BBQNnqnppp] b kq - 39 20", // many pieces in hand
+    "r1b1r1k1/ppp1Pppp/8/3p4/3P2P1/PN6/2PBQP1P/q1q1KB1R[NNbrnp] w - - 42 22",
+    "r3kb1r/1bpppppp/p1N2p2/2NPP3/2PP4/2N2Pb1/P3P1R1/R1Q2KBq[Pn] w kq - 54 28",
+    "7k/Q2P1pp1/2PPpn1p/3p1b2/3P4/P1n1P3/P1n1bPPP/R1B3KR[RRqbnp] w - - 48 25", // promotion
+
+    // Checkmate
+    "r1b2rk1/pppp1ppp/2P2b2/1N6/5N2/4P1K1/P1P4P/1Nrb1b1n[NPPQQrp] w - - 64 33",
+    "1Rbk3r/p1pQ1ppp/2Bn3n/4p1b1/4Pn2/3p4/PbPP1PPP/3RK1R1[QPPn] b - - 45 23",
+
+    // Stalemate
+    "2R5/3Q2pk/2p1p3/1pP1P1Qp/1P3P1P/p1P1B3/P7/1R2K3[NRBNPBPRNPBN] b - - 98 55",
+  },
+#endif
+#ifdef SLIPPEDGRID
+  {
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  },
+#endif
+#ifdef TWOKINGSSYMMETRIC
+  {
+    "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1",
+    "r1b1kk1r/pp1ppppp/2N2n2/8/4P3/2N5/PPP2qPP/R1BQKK1R w KQkq - 0 7",
+    "rnbqk2r/ppppkppp/5n2/4p3/4P3/5N2/PPPPKPPP/RNBQK2R w KQkq - 4 4"
+  },
+#endif
 };
 
 const int defaultDepth[VARIANT_NB] = {
@@ -353,7 +440,7 @@ vector<string> setup_bench(const Position& current, istream& is) {
   go = "go " + limitType + " " + limit;
 
   if (fenFile == "default")
-      fens = Defaults[mainVariant];
+      fens = Defaults[variant];
 
   else if (fenFile == "current")
       fens.push_back(current.fen());

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -40,7 +40,7 @@ Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
 Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 #ifdef GRID
-Bitboard GridBB[SQUARE_NB];
+Bitboard GridBB[GRIDLAYOUT_NB][SQUARE_NB];
 #endif
 
 Magic RookMagics[SQUARE_NB];
@@ -226,7 +226,26 @@ void Bitboards::init() {
 
 #ifdef GRID
   for (Square s = SQ_A1; s <= SQ_H8; ++s)
-      GridBB[s] = SquareBB[s] | SquareBB[s ^ 8] | SquareBB[s ^ 1] | SquareBB[s ^ 9];
+  {
+      GridBB[NORMAL_GRID][s]    = SquareBB[s] | SquareBB[s ^ 8] | SquareBB[s ^ 1] | SquareBB[s ^ 9];
+#ifdef DISPLACEDGRID
+      GridBB[DISPLACED_GRID][s] = SquareBB[s];
+      if (!((FileABB | FileHBB) & s))
+           GridBB[DISPLACED_GRID][s] |= SquareBB[((s + 1) ^ 1) - 1];
+      if (!((Rank1BB | Rank8BB) & s))
+           GridBB[DISPLACED_GRID][s] |= SquareBB[((s + 8) ^ 8) - 8];
+      if (!((Rank1BB | Rank8BB | FileABB | FileHBB) & s))
+           GridBB[DISPLACED_GRID][s] |= SquareBB[((s + 9) ^ 9) - 9];
+#endif
+#ifdef SLIPPEDGRID
+      GridBB[SLIPPED_GRID][s] = SquareBB[s] | SquareBB[s ^ 8];
+      if (!((FileABB | FileHBB) & s))
+      {
+           GridBB[SLIPPED_GRID][s] |= SquareBB[((s + 1) ^ 1) - 1];
+           GridBB[SLIPPED_GRID][s] |= SquareBB[(((s + 1) ^ 1) - 1) ^ 8];
+      }
+#endif
+  }
 #endif
 }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -76,7 +76,7 @@ extern Bitboard PawnAttackSpan[COLOR_NB][SQUARE_NB];
 extern Bitboard PseudoAttacks[PIECE_TYPE_NB][SQUARE_NB];
 extern Bitboard PawnAttacks[COLOR_NB][SQUARE_NB];
 #ifdef GRID
-extern Bitboard GridBB[SQUARE_NB];
+extern Bitboard GridBB[GRIDLAYOUT_NB][SQUARE_NB];
 #endif
 
 
@@ -162,8 +162,8 @@ inline Bitboard file_bb(Square s) {
 }
 
 #ifdef GRID
-inline Bitboard grid_bb(Square s) {
-  return GridBB[s];
+inline Bitboard grid_layout_bb(GridLayout l, Square s) {
+  return GridBB[l][s];
 }
 #endif
 

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -722,7 +722,7 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* moveList) {
       Square checksq = pop_lsb(&sliders);
 #ifdef GRID
       if (pos.is_grid())
-          sliderAttacks |= (LineBB[checksq][ksq] ^ checksq) & ~grid_bb(checksq);
+          sliderAttacks |= (LineBB[checksq][ksq] ^ checksq) & ~pos.grid_bb(checksq);
       else
 #endif
       sliderAttacks |= LineBB[checksq][ksq] ^ checksq;

--- a/src/position.h
+++ b/src/position.h
@@ -209,6 +209,14 @@ public:
 #endif
 #ifdef GRID
   bool is_grid() const;
+  GridLayout grid_layout() const;
+  Bitboard grid_bb(Square s) const;
+#endif
+#ifdef DISPLACEDGRID
+  bool is_displaced_grid() const;
+#endif
+#ifdef SLIPPEDGRID
+  bool is_slipped_grid() const;
 #endif
 #ifdef KOTH
   bool is_koth() const;
@@ -618,6 +626,42 @@ inline bool Position::is_extinction_loss() const {
 #ifdef GRID
 inline bool Position::is_grid() const {
   return var == GRID_VARIANT;
+}
+
+inline GridLayout Position::grid_layout() const {
+  assert(var == GRID_VARIANT);
+  switch (subvar)
+  {
+  case GRID_VARIANT:
+      return NORMAL_GRID;
+#ifdef DISPLACEDGRID
+  case DISPLACEDGRID_VARIANT:
+      return DISPLACED_GRID;
+#endif
+#ifdef SLIPPEDGRID
+  case SLIPPEDGRID_VARIANT:
+      return SLIPPED_GRID;
+#endif
+  default:
+      assert(false);
+      return NORMAL_GRID;
+  }
+}
+
+inline Bitboard Position::grid_bb(Square s) const {
+  return grid_layout_bb(grid_layout(), s);
+}
+#endif
+
+#ifdef DISPLACEDGRID
+inline bool Position::is_displaced_grid() const {
+  return subvar == DISPLACEDGRID_VARIANT;
+}
+#endif
+
+#ifdef SLIPPEDGRID
+inline bool Position::is_slipped_grid() const {
+  return subvar == SLIPPEDGRID_VARIANT;
 }
 #endif
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -98,7 +98,13 @@ const char* WdlSuffixes[SUBVARIANT_NB] = {
 #ifdef BUGHOUSE
     nullptr,
 #endif
+#ifdef DISPLACEDGRID
+    nullptr,
+#endif
 #ifdef LOOP
+    nullptr,
+#endif
+#ifdef SLIPPEDGRID
     nullptr,
 #endif
 #ifdef TWOKINGSSYMMETRIC
@@ -150,7 +156,13 @@ const char* PawnlessWdlSuffixes[SUBVARIANT_NB] = {
 #ifdef BUGHOUSE
     nullptr,
 #endif
+#ifdef DISPLACEDGRID
+    nullptr,
+#endif
 #ifdef LOOP
+    nullptr,
+#endif
+#ifdef SLIPPEDGRID
     nullptr,
 #endif
 #ifdef TWOKINGSSYMMETRIC
@@ -202,7 +214,13 @@ const char* DtzSuffixes[SUBVARIANT_NB] = {
 #ifdef BUGHOUSE
     nullptr,
 #endif
+#ifdef DISPLACEDGRID
+    nullptr,
+#endif
 #ifdef LOOP
+    nullptr,
+#endif
+#ifdef SLIPPEDGRID
     nullptr,
 #endif
 #ifdef TWOKINGSSYMMETRIC
@@ -254,7 +272,13 @@ const char* PawnlessDtzSuffixes[SUBVARIANT_NB] = {
 #ifdef BUGHOUSE
     nullptr,
 #endif
+#ifdef DISPLACEDGRID
+    nullptr,
+#endif
 #ifdef LOOP
+    nullptr,
+#endif
+#ifdef SLIPPEDGRID
     nullptr,
 #endif
 #ifdef TWOKINGSSYMMETRIC
@@ -1696,7 +1720,19 @@ void* init(Entry& e, const Position& pos) {
             { 0x71, 0xE8, 0x23, 0x5D }
         },
 #endif
+#ifdef DISPLACEDGRID
+        {
+            { 0xD7, 0x66, 0x0C, 0xA5 },
+            { 0x71, 0xE8, 0x23, 0x5D }
+        },
+#endif
 #ifdef LOOP
+        {
+            { 0xD7, 0x66, 0x0C, 0xA5 },
+            { 0x71, 0xE8, 0x23, 0x5D }
+        },
+#endif
+#ifdef SLIPPEDGRID
         {
             { 0xD7, 0x66, 0x0C, 0xA5 },
             { 0x71, 0xE8, 0x23, 0x5D }
@@ -1799,7 +1835,19 @@ void* init(Entry& e, const Position& pos) {
             { 0x71, 0xE8, 0x23, 0x5D }
         },
 #endif
+#ifdef DISPLACEDGRID
+        {
+            { 0xD7, 0x66, 0x0C, 0xA5 },
+            { 0x71, 0xE8, 0x23, 0x5D }
+        },
+#endif
 #ifdef LOOP
+        {
+            { 0xD7, 0x66, 0x0C, 0xA5 },
+            { 0x71, 0xE8, 0x23, 0x5D }
+        },
+#endif
+#ifdef SLIPPEDGRID
         {
             { 0xD7, 0x66, 0x0C, 0xA5 },
             { 0x71, 0xE8, 0x23, 0x5D }

--- a/src/types.h
+++ b/src/types.h
@@ -157,8 +157,14 @@ enum Variant {
 #ifdef BUGHOUSE
   BUGHOUSE_VARIANT,
 #endif
+#ifdef DISPLACEDGRID
+  DISPLACEDGRID_VARIANT,
+#endif
 #ifdef LOOP
   LOOP_VARIANT,
+#endif
+#ifdef SLIPPEDGRID
+  SLIPPEDGRID_VARIANT,
 #endif
 #ifdef TWOKINGSSYMMETRIC
   TWOKINGSSYMMETRIC_VARIANT,
@@ -213,8 +219,14 @@ static std::vector<std::string> variants = {
 #ifdef BUGHOUSE
 "bughouse",
 #endif
+#ifdef DISPLACEDGRID
+"displacedgrid",
+#endif
 #ifdef LOOP
 "loop",
+#endif
+#ifdef SLIPPEDGRID
+"slippedgrid",
 #endif
 #ifdef TWOKINGSSYMMETRIC
 "twokingssymmetric",
@@ -278,6 +290,19 @@ template<Color C, CastlingSide S> struct MakeCastling {
   right = C == WHITE ? S == QUEEN_SIDE ? WHITE_OOO : WHITE_OO
                      : S == QUEEN_SIDE ? BLACK_OOO : BLACK_OO;
 };
+
+#ifdef GRID
+enum GridLayout {
+  NORMAL_GRID,
+#ifdef DISPLACEDGRID
+  DISPLACED_GRID,
+#endif
+#ifdef SLIPPEDGRID
+  SLIPPED_GRID,
+#endif
+  GRIDLAYOUT_NB
+};
+#endif
 
 #ifdef THREECHECK
 enum CheckCount : int {
@@ -724,9 +749,17 @@ inline Variant main_variant(Variant v) {
   case BUGHOUSE_VARIANT:
       return CRAZYHOUSE_VARIANT;
 #endif
+#ifdef DISPLACEDGRID
+  case DISPLACEDGRID_VARIANT:
+      return GRID_VARIANT;
+#endif
 #ifdef LOOP
   case LOOP_VARIANT:
       return CRAZYHOUSE_VARIANT;
+#endif
+#ifdef SLIPPEDGRID
+  case SLIPPEDGRID_VARIANT:
+      return GRID_VARIANT;
 #endif
 #ifdef TWOKINGSSYMMETRIC
   case TWOKINGSSYMMETRIC_VARIANT:

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -84,8 +84,14 @@ namespace {
 #ifdef BUGHOUSE
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1",
 #endif
+#ifdef DISPLACEDGRID
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+#endif
 #ifdef LOOP
   "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[] w KQkq - 0 1",
+#endif
+#ifdef SLIPPEDGRID
+  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
 #endif
 #ifdef TWOKINGSSYMMETRIC
   "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1",


### PR DESCRIPTION
Since the implementation of grid chess is independent from the layout of the grid, we can easily support other layouts by changing the bitboards that define the grid cells. Both variants were tested in 50 games with cutechess.

The second commit is necessary to make `bench all` run through, since positions can be legal in one grid layout and illegal in another. The distinction of subvariant bench positions is also useful for twokings (connected kings in symmetric/asymmetric version) and loop chess (since we should not have promoted pieces in the FEN).