### PR TITLE
Tweak piece values for atomic chess

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -356,11 +356,11 @@ enum Value : int {
   KingValueMgAnti   = -23,   KingValueEgAnti   = 173,
 #endif
 #ifdef ATOMIC
-  PawnValueMgAtomic   = 296,   PawnValueEgAtomic   = 402,
-  KnightValueMgAtomic = 426,   KnightValueEgAtomic = 691,
-  BishopValueMgAtomic = 581,   BishopValueEgAtomic = 756,
-  RookValueMgAtomic   = 838,   RookValueEgAtomic   = 1103,
-  QueenValueMgAtomic  = 1545,  QueenValueEgAtomic  = 2033,
+  PawnValueMgAtomic   = 244,   PawnValueEgAtomic   = 367,
+  KnightValueMgAtomic = 437,   KnightValueEgAtomic = 652,
+  BishopValueMgAtomic = 552,   BishopValueEgAtomic = 716,
+  RookValueMgAtomic   = 787,   RookValueEgAtomic   = 1074,
+  QueenValueMgAtomic  = 1447,  QueenValueEgAtomic  = 1892,
 #endif
 #ifdef CRAZYHOUSE
   PawnValueMgHouse   = 140,   PawnValueEgHouse   = 232,


### PR DESCRIPTION
STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 10078 W: 3237 L: 3038 D: 3803
http://35.161.250.236:6543/tests/view/5a10a9b86e23db617088d938

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 5027 W: 1530 L: 1398 D: 2099
http://35.161.250.236:6543/tests/view/5a117a586e23db617088d941