### PR TITLE
Change capture_or_promotion for racing kings

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -1085,7 +1085,7 @@ inline bool Position::capture_or_promotion(Move m) const {
   if (is_race())
   {
     Square from = from_sq(m), to = to_sq(m);
-    return (type_of(board[from]) == KING && rank_of(to) >= rank_of(from)) || !empty(to);
+    return (type_of(board[from]) == KING && rank_of(to) > rank_of(from)) || !empty(to);
   }
 #endif
 #ifdef CRAZYHOUSE


### PR DESCRIPTION
Do not treat king moves to same rank as captures to make it consistent with move generation.

STC (failed)
LLR: -2.98 (-2.94,2.94) [0.00,10.00]
Total: 10755 W: 3038 L: 2985 D: 4732
http://35.161.250.236:6543/tests/view/5a18070d6e23db0a03ee327b

LTC
LLR: 2.98 (-2.94,2.94) [0.00,10.00]
Total: 9865 W: 2677 L: 2497 D: 4691
http://35.161.250.236:6543/tests/view/5a1869cb6e23db0a03ee3286

LTC2
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 17441 W: 4738 L: 4473 D: 8230
http://35.161.250.236:6543/tests/view/5a190fbc6e23db0a03ee3291