### PR TITLE
Fix #466: Evaluation overflow in atomic chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1104,6 +1104,10 @@ namespace {
                 kingDanger = ThreeCheckKSFactors[pos.checks_given(Them)] * kingDanger / 256;
 #endif
             int v = kingDanger * kingDanger / 4096;
+#ifdef ATOMIC
+            if (pos.is_atomic() && v > QueenValueMg)
+                v = QueenValueMg;
+#endif
 #ifdef CRAZYHOUSE
             if (pos.is_house() && Us == pos.side_to_move())
                 v -= v / 10;


### PR DESCRIPTION
The two additional LTC tests suggest that the fix is roughly Elo neutral despite the first test failed.

STC
LLR: 2.97 (-2.94,2.94) [-10.00,5.00]
Total: 3629 W: 1183 L: 1155 D: 1291
http://35.161.250.236:6543/tests/view/5a1c1a266e23db0a03ee32b1

LTC1
LLR: -2.99 (-2.94,2.94) [-10.00,5.00]
Total: 8189 W: 2313 L: 2410 D: 3466
http://35.161.250.236:6543/tests/view/5a1c1a506e23db0a03ee32b4

LTC2
LLR: 2.98 (-2.94,2.94) [-10.00,5.00]
Total: 2433 W: 710 L: 676 D: 1047
http://35.161.250.236:6543/tests/view/5a1db1c36e23db35f28baf37

LTC Elo measurement
ELO: 2.08 +-7.4 (95%) LOS: 71.0%
Total: 5000 W: 1478 L: 1448 D: 2074
http://35.161.250.236:6543/tests/view/5a1e5a2c6e23db35f28baf39