### PR TITLE
Use capture history in racing kings

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -147,7 +147,8 @@ void MovePicker::score() {
 #ifdef RACE
           if (pos.is_race())
               m.value = PieceValue[pos.variant()][MG][pos.piece_on(to_sq(m))]
-                      - Value(200 * relative_rank(BLACK, to_sq(m)));
+                      - Value(200 * relative_rank(BLACK, to_sq(m)))
+                      + Value((*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))]);
           else
 #endif
           m.value =  PieceValue[pos.variant()][MG][pos.piece_on(to_sq(m))]


### PR DESCRIPTION
STC
LLR: 2.98 (-2.94,2.94) [0.00,10.00]
Total: 1032 W: 342 L: 257 D: 433
http://35.161.250.236:6543/tests/view/5a2480d36e23db35f28baf5f

LTC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 1060 W: 308 L: 228 D: 524
http://35.161.250.236:6543/tests/view/5a2481346e23db35f28baf62