### PR TITLE
Fix quiet check move generation for losers chess

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -602,6 +602,10 @@ ExtMove* generate<QUIET_CHECKS>(const Position& pos, ExtMove* moveList) {
   if (pos.is_extinction())
       return moveList;
 #endif
+#ifdef LOSERS
+  if (pos.is_losers() && pos.can_capture_losers())
+      return moveList;
+#endif
 #ifdef RACE
   if (pos.is_race())
       return moveList;

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -826,6 +826,9 @@ bool Position::legal(Move m) const {
 #else
   assert(piece_on(square<KING>(us)) == make_piece(us, KING));
 #endif
+#ifdef LOSERS
+  assert(!(is_losers() && !capture(m) && can_capture_losers()));
+#endif
 
 #ifdef RACE
   // Checking moves are illegal


### PR DESCRIPTION
If we can capture, then there are no quiet checks.

STC
LLR: 2.99 (-2.94,2.94) [-10.00,5.00]
Total: 713 W: 344 L: 287 D: 82
http://35.161.250.236:6543/tests/view/5a2bc78c6e23db35f28baf9c

LTC
LLR: 2.96 (-2.94,2.94) [-10.00,5.00]
Total: 569 W: 284 L: 226 D: 59
http://35.161.250.236:6543/tests/view/5a2bd7326e23db35f28bafa0

I found this when using the debugging code from https://github.com/ianfab/Stockfish/commit/323a0cf0f7b5e6686d5266ba15fd1e3f15dff339.