### PR TITLE
Exclude illegal moves from mobility in grid chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -850,6 +850,10 @@ namespace {
           : Pt ==   ROOK ? attacks_bb<  ROOK>(s, pos.pieces() ^ pos.pieces(QUEEN) ^ pos.pieces(Us, ROOK))
                          : pos.attacks_from<Pt>(s);
 
+#ifdef GRID
+        if (pos.is_grid())
+            b &= ~pos.grid_bb(s);
+#endif
         if (pos.pinned_pieces(Us) & s)
             b &= LineBB[pos.square<KING>(Us)][s];
 


### PR DESCRIPTION
STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 746 W: 214 L: 139 D: 393
http://35.161.250.236:6543/tests/view/5a43cd5a6e23db35f28bb0b7

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 725 W: 178 L: 108 D: 439
http://35.161.250.236:6543/tests/view/5a44106e6e23db35f28bb0e3