### PR TITLE
Fix generation of pawn promotions for losers chess

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -122,6 +122,19 @@ namespace {
         return moveList;
     }
 #endif
+#ifdef LOSERS
+    if (V == LOSERS_VARIANT)
+    {
+        if (Type == QUIETS || Type == CAPTURES || Type == NON_EVASIONS)
+        {
+            *moveList++ = make<PROMOTION>(to - D, to, QUEEN);
+            *moveList++ = make<PROMOTION>(to - D, to, ROOK);
+            *moveList++ = make<PROMOTION>(to - D, to, BISHOP);
+            *moveList++ = make<PROMOTION>(to - D, to, KNIGHT);
+        }
+        return moveList;
+    }
+#endif
     if (Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
         *moveList++ = make<PROMOTION>(to - D, to, QUEEN);
 


### PR DESCRIPTION
Since quiet moves are filtered out in move generation of captures
and vice versa, queen promotions are suppressed in move generation,
because they are handled as captures even if they are quiet moves.

Example:
8/p5P1/2p5/8/6k1/8/6K1/8 b - - 0 1
Position is mate in 2 if pawn is promoted to queen, but search only finds
mate in 3 by promotion to rook since search is blind to queen promotions.

```
setoption name UCI_Variant value losers
position fen 8/p5P1/2p5/8/6k1/8/6K1/8 b - - 0 1
go depth 10
```

**master**
```
info depth 1 seldepth 1 multipv 1 score cp -224 nodes 8 nps 8000 tbhits 0 time 1 pv g4f5
info depth 2 seldepth 2 multipv 1 score cp -368 nodes 107 nps 107000 tbhits 0 time 1 pv g4f4 g7g8b
info depth 3 seldepth 3 multipv 1 score cp -237 nodes 377 nps 188500 tbhits 0 time 2 pv g4f5 g7g8b f5e5
info depth 4 seldepth 4 multipv 1 score cp -268 nodes 682 nps 341000 tbhits 0 time 2 pv g4f4 g2h3 c6c5 h3h4
info depth 5 seldepth 5 multipv 1 score cp -207 nodes 1035 nps 517500 tbhits 0 time 2 pv g4f4 g2h3 c6c5 h3h4 c5c4
info depth 6 seldepth 8 multipv 1 score mate -3 nodes 2042 nps 680666 tbhits 0 time 3 pv g4f4 g7g8r f4e3 g8g3 e3e2 g3e3 e2e3
info depth 7 seldepth 8 multipv 1 score mate -3 nodes 2225 nps 741666 tbhits 0 time 3 pv g4f4 g7g8r f4e3 g8g3 e3e2 g3e3 e2e3
info depth 8 seldepth 8 multipv 1 score mate -3 nodes 2436 nps 812000 tbhits 0 time 3 pv g4f4 g7g8r f4e3 g8g3 e3e2 g3e3 e2e3
info depth 9 seldepth 8 multipv 1 score mate -3 nodes 2792 nps 698000 tbhits 0 time 4 pv g4f4 g7g8r f4e3 g8g3 e3e2 g3e3 e2e3
info depth 10 seldepth 8 multipv 1 score mate -3 nodes 3360 nps 840000 tbhits 0 time 4 pv g4f4 g7g8r f4e3 g8g3 e3e2 g3e3 e2e3
bestmove g4f4 ponder g7g8r
```


**fix**
```
info depth 1 seldepth 1 multipv 1 score cp -224 nodes 8 nps 8000 tbhits 0 time 1 pv g4f5
info depth 2 seldepth 2 multipv 1 score cp -368 nodes 128 nps 128000 tbhits 0 time 1 pv g4f4 g7g8b
info depth 3 seldepth 3 multipv 1 score cp -560 nodes 330 nps 330000 tbhits 0 time 1 pv g4f4 g7g8q f4e3 g8b3 e3e4
info depth 4 seldepth 5 multipv 1 score mate -3 nodes 453 nps 453000 tbhits 0 time 1 pv g4f4 g7g8q f4e3 g8b3 e3e4 b3d3 e4d3
info depth 5 seldepth 7 multipv 1 score mate -2 nodes 629 nps 629000 tbhits 0 time 1 pv g4f4 g7g8q f4e3 g8d5 c6d5
info depth 6 seldepth 6 multipv 1 score mate -2 nodes 802 nps 802000 tbhits 0 time 1 pv g4f4 g7g8q f4e3 g8d5 c6d5
info depth 7 seldepth 6 multipv 1 score mate -2 nodes 1002 nps 501000 tbhits 0 time 2 pv g4f4 g7g8q f4e3 g8d5 c6d5
info depth 8 seldepth 6 multipv 1 score mate -2 nodes 1185 nps 592500 tbhits 0 time 2 pv g4f4 g7g8q f4e3 g8d5 c6d5
info depth 9 seldepth 6 multipv 1 score mate -2 nodes 1452 nps 726000 tbhits 0 time 2 pv g4f4 g7g8q f4e3 g8d5 c6d5
info depth 10 seldepth 6 multipv 1 score mate -2 nodes 1806 nps 903000 tbhits 0 time 2 pv g4f4 g7g8q f4e3 g8d5 c6d5
bestmove g4f4 ponder g7g8q
```