### PR TITLE
Add crazyhouse drop mobility bonuses

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -60,6 +60,11 @@ const Bitboard Rank6BB = Rank1BB << (8 * 5);
 const Bitboard Rank7BB = Rank1BB << (8 * 6);
 const Bitboard Rank8BB = Rank1BB << (8 * 7);
 
+#ifdef CRAZYHOUSE
+const Bitboard Rank1234BB = Rank1BB | Rank2BB | Rank3BB | Rank4BB;
+const Bitboard Rank5678BB = Rank5BB | Rank6BB | Rank7BB | Rank8BB;
+#endif
+
 extern int SquareDistance[SQUARE_NB][SQUARE_NB];
 
 extern Bitboard SquareBB[SQUARE_NB];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -528,6 +528,7 @@ namespace {
   const int KingDangerInHand[PIECE_TYPE_NB] = {
     79, 16, 200, 61, 138, 152
   };
+  const Score DropMobilityBonus = S(30, 30);
 #endif
 
 #ifdef RACE
@@ -1661,6 +1662,14 @@ namespace {
     score += evaluate_pieces<WHITE, BISHOP>() - evaluate_pieces<BLACK, BISHOP>();
     score += evaluate_pieces<WHITE, ROOK  >() - evaluate_pieces<BLACK, ROOK  >();
     score += evaluate_pieces<WHITE, QUEEN >() - evaluate_pieces<BLACK, QUEEN >();
+
+#ifdef CRAZYHOUSE
+    if (pos.is_house()) {
+        // Positional bonus for potential drop points - unoccupied squares in enemy territory that are not attacked by enemy non-KQ pieces
+        mobility[WHITE] += DropMobilityBonus * popcount(~(attackedBy[BLACK][PAWN] | attackedBy[BLACK][KNIGHT] | attackedBy[BLACK][BISHOP] | attackedBy[BLACK][ROOK] | pos.pieces() | Rank1234BB));
+        mobility[BLACK] += DropMobilityBonus * popcount(~(attackedBy[WHITE][PAWN] | attackedBy[WHITE][KNIGHT] | attackedBy[WHITE][BISHOP] | attackedBy[WHITE][ROOK] | pos.pieces() | Rank5678BB));
+    }
+#endif
 
     score += mobility[WHITE] - mobility[BLACK];
 


### PR DESCRIPTION
This patch gives bonuses for having good drop mobility/potential. It's similar to the `dropSafe` code in the king evaluation, but generally covers the whole board passively. Hoping it could dampen erratic nature of crazyhouse evals by providing more accurate immediate evals.

To illustrate intuition regarding the bonus, consider the advance French `1. e4 e6 2. d4 d5 3. e5`. In normal chess, playing `e5` doesn't change control over the e4 square. But in crazyhouse it leaves e4 open for a potential piece drop (`3. e5` is a good move regardless). Another example to think about here below, white has played `b4`, greatly weakening a3 and b2. Even if black doesn't have a good piece in hand to exploit it yet, this is now a weak drop spot that could bother white in the future, or force white to spend a move to cover those squares again.
![image](https://user-images.githubusercontent.com/2491207/34655711-0e037678-f3c3-11e7-97e8-d84e036903ae.png)

This current implementation is pretty naive and crude, but very very cheap/efficient for the ground it covers. Exploring and tweaking this strategy seems promising for more ELO gains. Some further ideas for improvement:
* Look at singly contested squares - attacked once by the player and once by the opponent. Intuitively I feel like this is just as important as completely uncontested squares for drop potential. But I'm unsure how to implement this without requiring some expensive data structure.
* More weights based on pieces in hand. For example a drop on the 7th rank is in many cases effective with a pawn in hand.
* Weight each rank potential uniquely, since they're quite different with respect to drops. For example, usually only Q or R drops are effective on the back rank, and also back rank can clear up pretty quickly without pawn cover around. Although if you have nothing covering your back rank, you're probably ded anyways. 

Thanks for all your help and any feedback or advice is appreciated!

```
STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 1802 W: 924 L: 800 D: 78
http://35.161.250.236:6543/tests/view/5a51d7456e23db35f28bb179

LTC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 2628 W: 1319 L: 1183 D: 126
http://35.161.250.236:6543/tests/view/5a52566c6e23db35f28bb17f
```

  