### PR TITLE
Mostly skip passed pawn bonus for grid chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1409,6 +1409,9 @@ namespace {
 
         Score bonus = PassedRank[pos.variant()][r];
 
+#ifdef GRID
+        if (pos.is_grid()) {} else
+#endif
         if (w)
         {
             Square blockSq = s + Up;
@@ -1430,9 +1433,6 @@ namespace {
             if (pos.is_atomic())
                 bonus += make_score(0, king_proximity(Them, blockSq) * 5 * w);
             else
-#endif
-#ifdef GRID
-            if (pos.is_grid()) {} else
 #endif
             {
             // Adjust bonus based on the king's proximity


### PR DESCRIPTION
STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 464 W: 135 L: 66 D: 263
http://35.161.250.236:6543/tests/view/5a8df3756e23db0fbab0d49d

LTC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 468 W: 118 L: 52 D: 298
http://35.161.250.236:6543/tests/view/5a8df7256e23db0fbab0d4a3