### PR TITLE
Drawish scale factor for late endgame in grid chess

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1632,6 +1632,11 @@ namespace {
 #endif
     if (sf == SCALE_FACTOR_NORMAL || sf == SCALE_FACTOR_ONEPAWN)
     {
+#ifdef GRID
+        if (pos.is_grid() && pos.non_pawn_material(strongSide) <= RookValueMg)
+            sf = 10;
+        else
+#endif
         if (pos.opposite_bishops())
         {
             // Endgame with opposite-colored bishops and no other pieces (ignoring pawns)


### PR DESCRIPTION
STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 3529 W: 759 L: 662 D: 2108
http://35.161.250.236:6543/tests/view/5a9acbdb6e23db0fbab0d58a

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 2607 W: 504 L: 420 D: 1683
http://35.161.250.236:6543/tests/view/5a9b9b126e23db0fbab0d595