### PR TITLE
Respect variant-agnostic move encoding (fix #512)

### DIFF
--- a/src/position.h
+++ b/src/position.h
@@ -336,7 +336,7 @@ inline Piece Position::piece_on(Square s) const {
 
 inline Piece Position::moved_piece(Move m) const {
 #ifdef CRAZYHOUSE
-  if (is_house() && type_of(m) == DROP)
+  if (type_of(m) == DROP)
       return dropped_piece(m);
 #endif
   return board[from_sq(m)];


### PR DESCRIPTION
Since the move encoding is independent of the variant,
we also need to ignore this information in Position::moved_piece
in order to properly handle invalid drop moves from the TT in
other variants than crazyhouse.

No functional change when not switching variants between searches.