### PR TITLE
Use standard tablebases for twokings (fixes #471)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -881,9 +881,6 @@ namespace {
 #ifdef THREECHECK
     if (pos.is_three_check()) {} else
 #endif
-#ifdef TWOKINGS
-    if (pos.is_two_kings()) {} else
-#endif
 #ifdef HORDE
     if (pos.is_horde()) {} else
 #endif

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -87,7 +87,7 @@ const char* WdlSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #endif
 #ifdef TWOKINGS
-    nullptr,
+    ".rtbw",
 #endif
 #ifdef SUICIDE
     ".stbw",
@@ -105,7 +105,7 @@ const char* WdlSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #endif
 #ifdef TWOKINGSSYMMETRIC
-    nullptr,
+    ".rtbw",
 #endif
 };
 
@@ -197,7 +197,7 @@ const char* DtzSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #endif
 #ifdef TWOKINGS
-    nullptr,
+    ".rtbz",
 #endif
 #ifdef SUICIDE
     ".stbz",
@@ -215,7 +215,7 @@ const char* DtzSuffixes[SUBVARIANT_NB] = {
     nullptr,
 #endif
 #ifdef TWOKINGSSYMMETRIC
-    nullptr,
+    ".rtbz",
 #endif
 };
 


### PR DESCRIPTION
If I understand the rules of twokings and symmetric twokings correctly, any position that is in a standard chess table is indeed completely equivalent to standard chess.

If that is true we can simply enable tablebases like so.