### PR TITLE
Conditionally skip early pruning in racing kings

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -973,6 +973,10 @@ namespace {
     if (pos.is_losers() && pos.can_capture_losers())
         goto moves_loop;
 #endif
+#ifdef RACE
+    if (pos.is_race() && (pos.pieces(KING) & (Rank7BB | Rank8BB)))
+        goto moves_loop;
+#endif
 #ifdef HORDE
     if (skipEarlyPruning || !(pos.is_horde() || pos.non_pawn_material(pos.side_to_move())))
 #else


### PR DESCRIPTION
Skip early pruning if one of the kings is on the 7th or 8th rank.

STC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 2141 W: 633 L: 538 D: 970
http://35.161.250.236:6543/tests/view/5ad1f4836e23db0fbab0d840

LTC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 2124 W: 614 L: 520 D: 990
http://35.161.250.236:6543/tests/view/5ad2f0f06e23db0fbab0d844