### PR TITLE
Skip futility pruning at parent node for losers chess

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1248,6 +1248,9 @@ moves_loop: // When in check, search starts from here
                   continue;
 
               // Futility pruning: parent node (~2 Elo)
+#ifdef LOSERS
+              if (pos.is_losers()) {} else
+#endif
               if (   lmrDepth < 7
                   && !inCheck
                   && ss->staticEval + FutilityMarginParent[pos.variant()][0] + FutilityMarginParent[pos.variant()][1] * lmrDepth <= alpha)


### PR DESCRIPTION
STC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 7188 W: 3259 L: 3065 D: 864
http://35.161.250.236:6543/tests/view/5ad652526e23db0fbab0d909

LTC
LLR: 2.95 (-2.94,2.94) [0.00,10.00]
Total: 6218 W: 2745 L: 2568 D: 905
http://35.161.250.236:6543/tests/view/5ad6e0516e23db0fbab0d90e