### PR TITLE
Skip futility pruning at parent node for racing kings

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1260,6 +1260,9 @@ moves_loop: // When in check, search starts from here
 #ifdef LOSERS
               if (pos.is_losers()) {} else
 #endif
+#ifdef RACE
+              if (pos.is_race()) {} else
+#endif
               if (   lmrDepth < 7
                   && !inCheck
                   && ss->staticEval + FutilityMarginParent[pos.variant()][0] + FutilityMarginParent[pos.variant()][1] * lmrDepth <= alpha)


### PR DESCRIPTION
STC
LLR: 2.96 (-2.94,2.94) [0.00,10.00]
Total: 9058 W: 2638 L: 2461 D: 3959
http://35.161.250.236:6543/tests/view/5ad7a0e96e23db0fbab0d911

LTC
LLR: 2.97 (-2.94,2.94) [0.00,10.00]
Total: 3318 W: 908 L: 802 D: 1608
http://35.161.250.236:6543/tests/view/5ad7b1c16e23db0fbab0d92b