### PR TITLE
Fix mate distance for odd ply counts

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -321,7 +321,7 @@ string UCI::value(Value v) {
   if (abs(v) < VALUE_MATE - MAX_PLY)
       ss << "cp " << v * 100 / PawnValueEg;
   else
-      ss << "mate " << (v > 0 ? VALUE_MATE - v + 1 : -VALUE_MATE - v) / 2;
+      ss << "mate " << (v > 0 ? VALUE_MATE - v + 1 : -VALUE_MATE - v - 1) / 2;
 
   return ss.str();
 }


### PR DESCRIPTION
The formula only worked correctly for even ply counts, but we can also have odd numbers in some variants.

There should be no functional change except for changed mate distances in racing kings, giveaway, losers, and extinction chess.

See discussion in https://github.com/ornicar/lila/issues/4248.