### PR TITLE
Remove redundant check for variant end

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1491,8 +1491,8 @@ moves_loop: // When in check, search starts from here
 
     if (!moveCount)
     {
+        assert(!pos.is_variant_end()); // was already checked
         bestValue =          excludedMove ? alpha
-                   : pos.is_variant_end() ? pos.variant_result(ss->ply, VALUE_DRAW)
                    :              inCheck ? pos.checkmate_value(ss->ply)
                    :                        pos.stalemate_value(ss->ply, VALUE_DRAW);
     }


### PR DESCRIPTION
No functional change.

The same check is already done at https://github.com/ddugovic/Stockfish/blob/3d0f894140229eb981f0611bc8db9375425e7a2b/src/search.cpp#L800-L801 so the second time it does not have any effect. To double check, I ran `bench all` and the assertion was not triggered.