### PR TITLE
Fix Analysis Contempt combo option

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -52,7 +52,6 @@ public:
   Option(const char* v, OnChange = nullptr);
   Option(const char* v, const std::vector<std::string>& variants, OnChange = nullptr);
   Option(double v, int minv, int maxv, OnChange = nullptr);
-  Option(const char* v, const char* cur, OnChange = nullptr);
 
   Option& operator=(const std::string&);
   void operator<<(const Option&);

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,7 +60,7 @@ void init(OptionsMap& o) {
 
   o["Debug Log File"]        << Option("", on_logger);
   o["Contempt"]              << Option(21, -100, 100);
-  o["Analysis Contempt"]     << Option("Both var Off var White var Black var Both", "Both");
+  o["Analysis Contempt"]     << Option("Both", {"Both", "Off", "White", "Black"});
   o["Threads"]               << Option(1, 1, 512, on_threads);
   o["Hash"]                  << Option(16, 1, MaxHashMB, on_hash_size);
   o["Clear Hash"]            << Option(on_clear_hash);
@@ -128,9 +128,6 @@ Option::Option(OnChange f) : type("button"), min(0), max(0), on_change(f)
 
 Option::Option(double v, int minv, int maxv, OnChange f) : type("spin"), min(minv), max(maxv), on_change(f)
 { defaultValue = currentValue = std::to_string(v); }
-
-Option::Option(const char* v, const char* cur, OnChange f) : type("combo"), min(0), max(0), on_change(f)
-{ defaultValue = v; currentValue = cur; }
 
 Option::operator double() const {
   assert(type == "check" || type == "spin");


### PR DESCRIPTION
Currently `setoption name Analyis Contempt value Off` is not working as expected. Thanks to https://lichess.org/forum/lichess-feedback/sawtooth-evaluation and @Vinvin20 (https://github.com/ornicar/lila/issues/4437) for pointing this out.

---

The issue is subtle: A long time ago c029b619fc0cd18ae27e1578f9df2fe5b1e8b464 introduced validation for the variant `combo` option. The value is validated against a vector of allowed options. This was the only combo option at the time and all was good.

https://github.com/ddugovic/Stockfish/blob/1be834f7cc48050a9be961724717b3fb6cd01fd0/src/ucioption.cpp#L173

Then e9aeaad05266ca557a9496b5a17b4c5f82f0e946 added an incompatible definition for combo options in official Stockfish. But all values fail the validation, because no vector of allowed options is passed with the new constructor.

---

Either constructor seems fine, but there should only be one. This PR keeps the one with early (case sensitive) validation against a vector.