### PR TITLE
Drop 7 piece syzygy support for atomic/anti

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -726,8 +726,6 @@ class TBTables {
     typedef std::tuple<Key, TBTable<WDL>*, TBTable<DTZ>*> Entry;
 
 #if defined(ANTI)
-    static const int Size = 1 << 22; // 1024K table, indexed by key's 22 lsb
-#elif defined(ATOMIC)
     static const int Size = 1 << 18; // 256K table, indexed by key's 18 lsb
 #else
     static const int Size = 1 << 16; // 64K table, indexed by key's 16 lsb
@@ -2173,29 +2171,13 @@ void Tablebases::init(Variant variant, const std::string& paths) {
                         for (PieceType p5 = PAWN; p5 <= KING; ++p5) {
                             TBTables.add(variant, {p1, p2, p3, p4}, {p5});
 
-                            for (PieceType p6 = PAWN; p6 <= p5; ++p6) {
+                            for (PieceType p6 = PAWN; p6 <= p5; ++p6)
                                 TBTables.add(variant, {p1, p2, p3, p4}, {p5, p6});
-
-                                for (PieceType p7 = PAWN; p7 <= p6; ++p7)
-                                    TBTables.add(variant, {p1, p2, p3, p4}, {p5, p6, p7});
-                            }
                         }
 
-                        for (PieceType p5 = PAWN; p5 <= p4; ++p5) {
-                            for (PieceType p6 = PAWN; p6 <= KING; ++p6) {
+                        for (PieceType p5 = PAWN; p5 <= p4; ++p5)
+                            for (PieceType p6 = PAWN; p6 <= KING; ++p6)
                                 TBTables.add(variant, {p1, p2, p3, p4, p5}, {p6});
-
-                                for (PieceType p7 = PAWN; p7 <= p6; ++p7)
-                                    TBTables.add(variant, {p1, p2, p3, p4, p5}, {p6, p7});
-                            }
-                        }
-
-                        for (PieceType p5 = PAWN; p5 <= p4; ++p5) {
-                            for (PieceType p6 = PAWN; p6 <= p5; ++p6) {
-                                for (PieceType p7 = PAWN; p7 <= KING; ++p7)
-                                    TBTables.add(variant, {p1, p2, p3, p4, p5, p6}, {p7});
-                            }
-                        }
                     }
 
                     for (PieceType p4 = PAWN; p4 <= p1; ++p4)


### PR DESCRIPTION
Good merge the other day!

I would suggest dropping 7 piece variant syzygy support for now. There are 1001 tables with 7 pieces for standard. But there are 15120 tables for antichess! (Always having two kings reduces the number of combinations a lot). This means that:

* It is unlikely that they will be generated anytime soon. It will require much more resources and at the same time there is less interest compared to standard chess.
* The estimates for the hashtable sizes are likely wrong, i.e. 1024K may not suffice. At some point it would probably better to use a different kind of hashtable.

Additionally 7 piece antichess would probably require some tweaks to the capture search, if not also to the indexing.