### PR TITLE
Fix #552 repetition detection for crazyhouse

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1768,7 +1768,11 @@ void Position::do_move(Move m, StateInfo& newSt, bool givesCheck) {
   // occurrence of the same position, negative in the 3-fold case, or zero
   // if the position was not repeated.
   st->repetition = 0;
+#ifdef CRAZYHOUSE
+  int end = is_house() ? st->pliesFromNull : std::min(st->rule50, st->pliesFromNull);
+#else
   int end = std::min(st->rule50, st->pliesFromNull);
+#endif
   if (end >= 4)
   {
       StateInfo* stp = st->previous->previous;


### PR DESCRIPTION
Testing indicates a small regression due to the overhead for repetition detection.

crazyhouse STC
LLR: -2.95 (-2.94,2.94) [-10.00,5.00]
Total: 2468 W: 1134 L: 1217 D: 117
http://35.161.250.236:6543/tests/view/5cf51eec6e23db34f4206b86

crazyhouse LTC
LLR: -2.95 (-2.94,2.94) [-10.00,5.00]
Total: 2980 W: 1340 L: 1425 D: 215
http://35.161.250.236:6543/tests/view/5cf54e516e23db34f4206b89