### PR TITLE
Fix pseudo-legal move validation for horde chess

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1211,7 +1211,12 @@ bool Position::pseudo_legal(const Move m) const {
       if (   !(attacks_from<PAWN>(from, us) & pieces(~us) & to) // Not a capture
           && !((from + pawn_push(us) == to) && empty(to))       // Not a single push
           && !(   (from + 2 * pawn_push(us) == to)              // Not a double push
+#ifdef HORDE
+               && (rank_of(from) == relative_rank(us, RANK_2)
+                   || (is_horde() && rank_of(from) == relative_rank(us, RANK_1)))
+#else
                && (rank_of(from) == relative_rank(us, RANK_2))
+#endif
                && empty(to)
                && empty(to - pawn_push(us))))
           return false;


### PR DESCRIPTION
Consider double steps from the first rank in pseudo-legal move validation.

horde STC
LLR: 2.96 (-2.94,2.94) [-10.00,5.00]
Total: 540 W: 299 L: 235 D: 6
http://35.161.250.236:6543/tests/view/5d45d8de6e23db34f4206d43