### PR TITLE
Double size of TBTables for Giveaway (fixes #558)

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -746,7 +746,7 @@ class TBTables {
     typedef std::tuple<Key, TBTable<WDL>*, TBTable<DTZ>*> Entry;
 
 #if defined(ANTI)
-    static constexpr int Size = 1 << 14; // 16K table, indexed by key's 14 lsb
+    static constexpr int Size = 1 << 15; // 32K table, indexed by key's 15 lsb
 #else
     static constexpr int Size = 1 << 12; // 4K table, indexed by key's 12 lsb
 #endif


### PR DESCRIPTION
Background:

The hashTable maps material configurations to Syzygy tables. Because
kings are not guaranteed to exist in Giveaway, there are 8400 tables with
up to 6 pieces, even much more than 1511 tables for up to 7 pieces in
standard chess.

Originally we were using a naive hashTable implementation with a 64K
table.

When introducing 7 piece tables, upstream improved efficiency by
switching to a kind of Robin Hood hashing, reducing the table size,
and we mistakenly reduced it slightly too much fore Giveaway
(166bf90e4172b77aa0c420ed271).