### PR TITLE
Fix evasion move generation for losers chess

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -45,7 +45,7 @@ namespace {
 #ifdef LOSERS
     if (V == LOSERS_VARIANT)
     {
-        if (Type == QUIETS || Type == CAPTURES || Type == NON_EVASIONS)
+        if (Type == QUIETS || Type == CAPTURES || Type == EVASIONS || Type == NON_EVASIONS)
         {
             *moveList++ = make<PROMOTION>(to - D, to, QUEEN);
             *moveList++ = make<PROMOTION>(to - D, to, ROOK);


### PR DESCRIPTION
Consider promotions in generation of evasions for losers chess.

Example:
```
setoption name UCI_Variant value losers
position fen r6K/1k4P1/8/8/8/8/8/8 w - - 0 1
go perft 1
```

master:
```
h8h7: 1

Nodes searched: 1
```

patch:
```
h8h7: 1
g7g8q: 1
g7g8r: 1
g7g8b: 1
g7g8n: 1

Nodes searched: 5
```

This probably slipped through because it is very rare that a promotion is a check evasion move, especially in losers chess. @ddugovic I only found it by coincidence when checking the code of your tests.