### PR TITLE
Fix TB initialization for variants

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -353,7 +353,7 @@ void Search::clear() {
   Time.availableNodes = 0;
   TT.clear();
   Threads.clear();
-  Tablebases::init(CHESS_VARIANT, Options["SyzygyPath"]); // Free mapped files
+  Tablebases::init(UCI::variant_from_name(Options["UCI_Variant"]), Options["SyzygyPath"]); // Free mapped files
 }
 
 


### PR DESCRIPTION
On every `ucinewgame` the TBs were re-initialized to standard chess irrespective of the currently set UCI_Variant value. Use the current variant for initialization instead.

Fixes #567.